### PR TITLE
Check meta refresh tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Many options of the following tests can customised. Items marked :soon: are not 
 - `a` `link`: Whether external links use HTTPS.
 - `img`: Whether your images have valid alt attributes.
 - `link`: Whether pages have a valid favicon.
+- `meta`: Whether refresh tags are valid and the url works.
 - `meta`: :soon: Whether images and URLs in the OpenGraph metadata are valid.
 - `meta` `title`: :soon: Whether you've got the [recommended tags](https://support.google.com/webmasters/answer/79812?hl=en) in your head.
 
@@ -90,12 +91,15 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `CheckLinks` | Enables checking `<link…` tags. | `true` |
 | `CheckImages` | Enables checking `<img…` tags | `true` |
 | `CheckScripts` | Enables checking `<script…` tags. | `true` |
+| `CheckMeta` | Enables checking `<meta…` tags. | `true` |
+| `CheckGeneric` | Enables other tags, see items marked with checkGeneric on the [tags wiki page](https://github.com/wjdp/htmltest/wiki/Tags). | `true` |
 | `CheckExternal` | Enables external reference checking; all tag types. | `true` |
 | `CheckInternal` | Enables internal reference checking; all tag types. | `true` |
 | `CheckInternalHash` | Enables internal hash/fragment checking. | `true` |
 | `CheckMailto` | Enables–albeit quite basic–`mailto:` link checking. | `true` |
 | `CheckTel` | Enables–albeit quite basic–`tel:` link checking. | `true` |
 | `CheckFavicon` | Enables favicon checking, ensures every page has a favicon set. | `false` |
+| `CheckMetaRefresh` | Enables checking meta refresh tags. | `true` |
 | `EnforceHTTPS` | Fails when encountering an `http://` link. Useful to prevent mixed content errors when serving over HTTPS. | `false` |
 | `IgnoreURLs` | Array of regexs of URLs to ignore. | empty |
 | `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files. | empty |

--- a/htmldoc/document.go
+++ b/htmldoc/document.go
@@ -71,8 +71,8 @@ func (doc *Document) parseNode(n *html.Node) {
 		// Identify and store tags of interest
 		switch n.Data {
 		case "a", "area", "audio", "blockquote", "del", "embed", "iframe", "img",
-			"input", "ins", "link", "object", "q", "script", "source", "track",
-			"video":
+			"input", "ins", "link", "meta", "object", "q", "script", "source",
+			"track", "video":
 			// Nodes of interest
 			doc.NodesOfInterest = append(doc.NodesOfInterest, n)
 		case "base":

--- a/htmltest/check-generic.go
+++ b/htmltest/check-generic.go
@@ -26,6 +26,11 @@ func (hT *HTMLTest) checkGeneric(document *htmldoc.Document, node *html.Node, ke
 		})
 	}
 
+	// Check the reference
+	hT.checkGenericRef(ref)
+}
+
+func (hT *HTMLTest) checkGenericRef(ref *htmldoc.Reference) {
 	// Route reference check
 	switch ref.Scheme() {
 	case "http":

--- a/htmltest/check-meta.go
+++ b/htmltest/check-meta.go
@@ -1,0 +1,67 @@
+package htmltest
+
+import (
+	// "fmt"
+	"github.com/wjdp/htmltest/htmldoc"
+	"github.com/wjdp/htmltest/issues"
+	"golang.org/x/net/html"
+	"regexp"
+	"strings"
+)
+
+func (hT *HTMLTest) checkMeta(document *htmldoc.Document, node *html.Node) {
+	hT.checkMetaRefresh(document, node)
+}
+
+func (hT *HTMLTest) checkMetaRefresh(document *htmldoc.Document, node *html.Node) {
+	attrs := htmldoc.ExtractAttrs(node.Attr,
+		[]string{"http-equiv", "content", hT.opts.IgnoreTagAttribute})
+
+	// Checks for meta refresh redirect tag
+	if attrs["http-equiv"] == "refresh" {
+		// Extract the timing and path from the content attr
+		contentSplit := strings.Split(attrs["content"], ";url=")
+		// Define ref from this
+		var ref *htmldoc.Reference
+		if len(contentSplit) == 2 {
+			ref = htmldoc.NewReference(document, node, contentSplit[1])
+		} else {
+			ref = htmldoc.NewReference(document, node, "")
+		}
+
+		// If refresh the content attribute must be set
+		if htmldoc.AttrPresent(node.Attr, "content") {
+
+			// Check content isn't blank
+			if len(attrs["content"]) == 0 {
+				hT.issueStore.AddIssue(issues.Issue{
+					Level:     issues.LevelError,
+					Message:   "blank content attribute in meta refresh",
+					Reference: ref,
+				})
+				return // stop
+			}
+
+			// Check the time is a positive integer, if the user has buggered up
+			// with ;url=... this will also display.
+			if ok, _ := regexp.MatchString("^\\d+$", contentSplit[0]); !ok {
+				hT.issueStore.AddIssue(issues.Issue{
+					Level:     issues.LevelError,
+					Message:   "invalid content attribute in meta refresh",
+					Reference: ref,
+				})
+			}
+
+			// Check the reference
+			hT.checkGenericRef(ref)
+
+		} else {
+			hT.issueStore.AddIssue(issues.Issue{
+				Level:     issues.LevelError,
+				Message:   "missing content attribute in meta refresh",
+				Reference: ref,
+			})
+		}
+
+	}
+}

--- a/htmltest/check-meta.go
+++ b/htmltest/check-meta.go
@@ -10,7 +10,9 @@ import (
 )
 
 func (hT *HTMLTest) checkMeta(document *htmldoc.Document, node *html.Node) {
-	hT.checkMetaRefresh(document, node)
+	if hT.opts.CheckMetaRefresh {
+		hT.checkMetaRefresh(document, node)
+	}
 }
 
 func (hT *HTMLTest) checkMetaRefresh(document *htmldoc.Document, node *html.Node) {

--- a/htmltest/check-meta_test.go
+++ b/htmltest/check-meta_test.go
@@ -1,0 +1,68 @@
+package htmltest
+
+import (
+	"testing"
+)
+
+// Passes for valid meta refresh without url.
+func TestMetaRefreshSelfValid(t *testing.T) {
+	hT := tTestFile("fixtures/meta/refresh-refresh.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
+// Passes for valid external meta refresh.
+func TestMetaRefreshExternalValid(t *testing.T) {
+	hT := tTestFile("fixtures/meta/refresh-external-valid.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
+// Fails broken external URL in meta refresh.
+func TestMetaRefreshExternalBroken(t *testing.T) {
+	hT := tTestFile("fixtures/meta/refresh-external-broken.html")
+	tExpectIssueCount(t, hT, 1)
+}
+
+// Passes for valid internal meta refresh.
+func TestMetaRefreshInternalValid(t *testing.T) {
+	hT := tTestFile("fixtures/meta/refresh-internal-valid.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
+// Fails for broken internal path in meta refresh.
+func TestMetaRefreshInternalBroken(t *testing.T) {
+	hT := tTestFile("fixtures/meta/refresh-internal-broken.html")
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "target does not exist", 1)
+}
+
+// Fails for missing content attribute when http-equiv="refresh" present.
+func TestMetaRefreshContentMissing(t *testing.T) {
+	hT := tTestFile("fixtures/meta/refresh-content-missing.html")
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "missing content attribute in meta refresh", 1)
+}
+
+// Fails for blank content attribute when http-equiv="refresh" present.
+func TestMetaRefreshContentBlank(t *testing.T) {
+	hT := tTestFile("fixtures/meta/refresh-content-blank.html")
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "blank content attribute in meta refresh", 1)
+}
+
+// Fails for invalid content attribute when http-equiv="refresh" present.
+// The attribute should be a positive integer and may be suffixed with ;url=
+// and a path.
+func TestMetaRefreshContentInvalid(t *testing.T) {
+	// Invalid when straight refresh
+	hT1 := tTestFile("fixtures/meta/refresh-content-invalid-refresh.html")
+	tExpectIssueCount(t, hT1, 1)
+	tExpectIssue(t, hT1, "invalid content attribute in meta refresh", 1)
+	// Invalid when a redirect
+	hT2 := tTestFile("fixtures/meta/refresh-content-invalid-redirect.html")
+	tExpectIssueCount(t, hT2, 1)
+	tExpectIssue(t, hT2, "invalid content attribute in meta refresh", 1)
+	// Malformed separator
+	hT3 := tTestFile("fixtures/meta/refresh-content-invalid-redirect.html")
+	tExpectIssueCount(t, hT3, 1)
+	tExpectIssue(t, hT3, "invalid content attribute in meta refresh", 1)
+}

--- a/htmltest/fixtures/meta/refresh-content-blank.html
+++ b/htmltest/fixtures/meta/refresh-content-blank.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-content-invalid-malformed.html
+++ b/htmltest/fixtures/meta/refresh-content-invalid-malformed.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="3x;abc=refresh-internal-broken.html">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-content-invalid-redirect.html
+++ b/htmltest/fixtures/meta/refresh-content-invalid-redirect.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="3x;url=refresh-internal-broken.html">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-content-invalid-refresh.html
+++ b/htmltest/fixtures/meta/refresh-content-invalid-refresh.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="-2">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-content-missing.html
+++ b/htmltest/fixtures/meta/refresh-content-missing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-external-broken.html
+++ b/htmltest/fixtures/meta/refresh-external-broken.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="3;url=http://www.mozilla.org/404/">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-external-valid.html
+++ b/htmltest/fixtures/meta/refresh-external-valid.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="3;url=http://www.mozilla.org/">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-internal-broken.html
+++ b/htmltest/fixtures/meta/refresh-internal-broken.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="3;url=nope.html">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-internal-valid.html
+++ b/htmltest/fixtures/meta/refresh-internal-valid.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="3;url=refresh-internal-broken.html">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/meta/refresh-refresh.html
+++ b/htmltest/fixtures/meta/refresh-refresh.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="2006">
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -140,6 +140,8 @@ func (hT *HTMLTest) testDocument(document *htmldoc.Document) {
 			if hT.opts.CheckScripts {
 				hT.checkScript(document, n)
 			}
+		case "meta":
+			hT.checkMeta(document, n)
 		case "area":
 			hT.checkGeneric(document, n, "href")
 		case "blockquote", "del", "ins", "q":

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -141,18 +141,30 @@ func (hT *HTMLTest) testDocument(document *htmldoc.Document) {
 				hT.checkScript(document, n)
 			}
 		case "meta":
-			hT.checkMeta(document, n)
+			if hT.opts.CheckMeta {
+				hT.checkMeta(document, n)
+			}
 		case "area":
-			hT.checkGeneric(document, n, "href")
+			if hT.opts.CheckGeneric {
+				hT.checkGeneric(document, n, "href")
+			}
 		case "blockquote", "del", "ins", "q":
-			hT.checkGeneric(document, n, "cite")
+			if hT.opts.CheckGeneric {
+				hT.checkGeneric(document, n, "cite")
+			}
 		case "iframe", "input", "audio", "embed", "source", "track":
-			hT.checkGeneric(document, n, "src")
+			if hT.opts.CheckGeneric {
+				hT.checkGeneric(document, n, "src")
+			}
 		case "video":
-			hT.checkGeneric(document, n, "src")
-			hT.checkGeneric(document, n, "poster")
+			if hT.opts.CheckGeneric {
+				hT.checkGeneric(document, n, "src")
+				hT.checkGeneric(document, n, "poster")
+			}
 		case "object":
-			hT.checkGeneric(document, n, "data")
+			if hT.opts.CheckGeneric {
+				hT.checkGeneric(document, n, "data")
+			}
 		}
 	}
 	hT.postChecks(document)

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -18,6 +18,8 @@ type Options struct {
 	CheckLinks   bool
 	CheckImages  bool
 	CheckScripts bool
+	CheckMeta    bool
+	CheckGeneric bool
 
 	CheckExternal     bool
 	CheckInternal     bool
@@ -25,7 +27,9 @@ type Options struct {
 	CheckMailto       bool
 	CheckTel          bool
 	CheckFavicon      bool
-	EnforceHTTPS      bool
+	CheckMetaRefresh  bool
+
+	EnforceHTTPS bool
 
 	IgnoreURLs []interface{}
 	IgnoreDirs []interface{}
@@ -67,6 +71,8 @@ func DefaultOptions() map[string]interface{} {
 		"CheckLinks":   true,
 		"CheckImages":  true,
 		"CheckScripts": true,
+		"CheckMeta":    true,
+		"CheckGeneric": true,
 
 		"CheckExternal":     true,
 		"CheckInternal":     true,
@@ -74,7 +80,9 @@ func DefaultOptions() map[string]interface{} {
 		"CheckMailto":       true,
 		"CheckTel":          true,
 		"CheckFavicon":      false,
-		"EnforceHTTPS":      false,
+		"CheckMetaRefresh":  true,
+
+		"EnforceHTTPS": false,
 
 		"IgnoreURLs": []interface{}{},
 		"IgnoreDirs": []interface{}{},


### PR DESCRIPTION
Add `meta` tags to NodesOfInterest.
Split generic ref checking from checkGeneric, make hT.checkGenericRef function.

Create check-meta.go, hT.checkMeta function. This checks meta tags.

Forward meta tags to this function when scanning through NodesOfInterest.

If a meta tag has `http-equiv == "refresh"` we check several things now:
- Is the content attr present and non-blank
- Is the first term in the content attr a positive integer
- Is the separator `;url=`
- Is what follows `;url`= a valid reference

Add options `CheckMeta`, `CheckGeneric` and `CheckMetaRefresh`.

Will close #20 and sets us up for opengraph checks, re #7.