### PR TITLE
Cleaner errors, implement output package.

### DIFF
--- a/buildme.sh
+++ b/buildme.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-go build -o ~/bin/htmltest -x main.go

--- a/htmldoc/document.go
+++ b/htmldoc/document.go
@@ -1,6 +1,7 @@
 package htmldoc
 
 import (
+	"github.com/wjdp/htmltest/output"
 	"golang.org/x/net/html"
 	"os"
 	"path"
@@ -48,11 +49,11 @@ func (doc *Document) Parse() {
 	}
 	// Open, parse, and close document
 	f, err := os.Open(doc.FilePath)
-	checkErr(err)
+	output.CheckErrorPanic(err)
 	defer f.Close()
 
 	htmlNode, err := html.Parse(f)
-	checkErr(err)
+	output.CheckErrorGeneric(err)
 
 	doc.htmlNode = htmlNode
 	doc.parseNode(htmlNode)

--- a/htmldoc/document_store.go
+++ b/htmldoc/document_store.go
@@ -4,6 +4,7 @@
 package htmldoc
 
 import (
+	"github.com/wjdp/htmltest/output"
 	"os"
 	"path"
 	"regexp"
@@ -58,17 +59,17 @@ func (dS *DocumentStore) discoverRecurse(dPath string) {
 
 	// Open directory to scan
 	f, err := os.Open(path.Join(dS.BasePath, dPath))
-	checkErr(err)
+	output.CheckErrorPanic(err)
 	defer f.Close()
 
 	// Get FileInfo of directory (scan it)
 	fi, err := f.Stat()
-	checkErr(err)
+	output.CheckErrorPanic(err)
 
 	if fi.IsDir() { // Double check we're dealing with a directory
 		// Read all FileInfo-s from directory, Readdir(count int)
 		fis, err := f.Readdir(-1)
-		checkErr(err)
+		output.CheckErrorPanic(err)
 
 		// Iterate over contents of directory
 		for _, fileinfo := range fis {

--- a/htmldoc/util.go
+++ b/htmldoc/util.go
@@ -1,11 +1,5 @@
 package htmldoc
 
-func checkErr(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
 // Return true if character at start or end of URL should be trimmed.
 func invalidPrePostRune(r rune) bool {
 	return r == '\n' || r == ' '

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -3,6 +3,7 @@ package htmltest
 import (
 	"github.com/wjdp/htmltest/htmldoc"
 	"github.com/wjdp/htmltest/issues"
+	"github.com/wjdp/htmltest/output"
 	"golang.org/x/net/html"
 	"log"
 	"net/http"
@@ -308,7 +309,7 @@ func (hT *HTMLTest) checkFile(ref *htmldoc.Reference, absPath string) {
 		})
 		return
 	}
-	checkErr(err) // Crash on other errors
+	output.CheckErrorPanic(err)
 
 	if f.IsDir() {
 		hT.issueStore.AddIssue(issues.Issue{

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -3,12 +3,11 @@
 package htmltest
 
 import (
-	"fmt"
 	"github.com/wjdp/htmltest/htmldoc"
 	"github.com/wjdp/htmltest/issues"
+	"github.com/wjdp/htmltest/output"
 	"github.com/wjdp/htmltest/refcache"
 	"net/http"
-	"os"
 	"path"
 	"sync"
 	"time"
@@ -73,15 +72,14 @@ func Test(optsUser map[string]interface{}) *HTMLTest {
 		// Single document mode
 		doc, ok := hT.documentStore.ResolvePath(hT.opts.FilePath)
 		if !ok {
-			fmt.Println("Could not find document", hT.opts.FilePath, "in", hT.opts.DirectoryPath)
-			os.Exit(1)
+			output.AbortWith("Could not find document", hT.opts.FilePath, "in", hT.opts.DirectoryPath)
 		}
 		hT.testDocument(doc)
 	} else if hT.opts.DirectoryPath != "" {
 		// Test documents
 		hT.testDocuments()
 	} else {
-		panic("Neither file or directory path provided")
+		output.AbortWith("Neither file or directory path provided")
 	}
 
 	if hT.opts.EnableCache {

--- a/htmltest/util.go
+++ b/htmltest/util.go
@@ -2,12 +2,6 @@ package htmltest
 
 import "net/http"
 
-func checkErr(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
 func statusCodeValid(code int) bool {
 	return code == http.StatusPartialContent || code == http.StatusOK
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docopt/docopt-go"
 	"github.com/fatih/color"
 	"github.com/wjdp/htmltest/htmltest"
+	"github.com/wjdp/htmltest/output"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
@@ -54,11 +55,16 @@ type optsMap map[string]interface{}
 
 func parseConfFile(path string) optsMap {
 	yamlFile, err := ioutil.ReadFile(path)
-	checkErr(err)
+
+	if os.IsNotExist(err) {
+		output.AbortWith(`No path provided & .htmltest.yml does not exist.
+See htmltest -h for usage.`)
+	}
+	output.CheckErrorGeneric(err)
 
 	var optsUser optsMap
 	err = yaml.Unmarshal(yamlFile, &optsUser)
-	checkErr(err)
+	output.CheckErrorGeneric(err)
 
 	return optsUser
 }
@@ -78,12 +84,6 @@ func parseCLIArgs(arguments map[string]interface{}) optsMap {
 		options["LogLevel"] = arguments["--log-level"]
 	}
 	return options
-}
-
-func checkErr(err error) {
-	if err != nil {
-		panic(err)
-	}
 }
 
 func run(options optsMap) int {

--- a/output/error.go
+++ b/output/error.go
@@ -1,0 +1,33 @@
+package output
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"os"
+)
+
+// CheckErrorGeneric aborts if error present with its message.
+// Use for when error is not abnormal.
+func CheckErrorGeneric(err error) {
+	if err != nil {
+		AbortWith(err.Error())
+	}
+}
+
+// CheckErrorPanic panics when error is present with its message.
+// Use when the presence of the error is not expected under the great majority
+// of circumstances.
+func CheckErrorPanic(err error) {
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+// AbortWith prints the provided message and ends execution of the program
+// with code 1.
+func AbortWith(a ...interface{}) {
+	color.Set(color.FgRed)
+	fmt.Println(a...)
+	color.Unset()
+	os.Exit(1)
+}


### PR DESCRIPTION
- Calls to package specific checkErr methods replaced with single CheckErrorPanic() method.
- Addition of CheckErrorGeneric(), same as CheckErrorPanic but without the panic call, prints error and calls os.Exit(1).
- Addition of AbortWith method, handles exiting nicely -- print red and exit with os.Exit(1). CheckErrorGeneric calls this.
- Replacement of common errors (missing CLI args, missing config file) calling panic -> CheckErrorGeneric or AbortWith.
- Will close #17.


Example when calling program without path or config file.
```
~ ❯❯❯ htmltest
No path provided & .htmltest.yml does not exist.
See htmltest -h for usage.
```