### PR TITLE
Ignore blank internal hashes via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `CheckMeta` | Enables checking `<meta…` tags. | `true` |
 | `CheckGeneric` | Enables other tags, see items marked with checkGeneric on the [tags wiki page](https://github.com/wjdp/htmltest/wiki/Tags). | `true` |
 | `CheckExternal` | Enables external reference checking; all tag types. | `true` |
-| `CheckInternal` | Enables internal reference checking; all tag types. | `true` |
+| `CheckInternal` | Enables internal reference checking; all tag types. When disabled will prevent internal hash checking unless the reference only contains a hash fragment (`#heading`) and therefore refers to the current page. | `true` |
 | `CheckInternalHash` | Enables internal hash/fragment checking. | `true` |
 | `CheckMailto` | Enables–albeit quite basic–`mailto:` link checking. | `true` |
 | `CheckTel` | Enables–albeit quite basic–`tel:` link checking. | `true` |
@@ -103,7 +103,8 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `EnforceHTTPS` | Fails when encountering an `http://` link. Useful to prevent mixed content errors when serving over HTTPS. | `false` |
 | `IgnoreURLs` | Array of regexs of URLs to ignore. | empty |
 | `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files. | empty |
-| `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |
+| `IgnoreInternalEmptyHash` | When true produces a warning, rather than an error, for links with `href="#"`. | `false` |
+| `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |
 | `IgnoreAltMissing` | Turns off image alt attribute checking. | `false` |
 | `IgnoreDirectoryMissingTrailingSlash` | Turns off errors for links to directories without a trailing slash. | `false` |
 | `IgnoreTagAttribute` | Specify the ignore attribute. All tags with this attribute will be excluded from every check. | `"data-proofer-ignore"` |

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -63,11 +63,13 @@ func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 
 	// href="#"
 	if attrs["href"] == "#" {
-		hT.issueStore.AddIssue(issues.Issue{
-			Level:     issues.LevelError,
-			Message:   "empty hash",
-			Reference: ref,
-		})
+		if hT.opts.CheckInternalHash && !hT.opts.IgnoreInternalEmptyHash {
+			hT.issueStore.AddIssue(issues.Issue{
+				Level:     issues.LevelError,
+				Message:   "empty hash",
+				Reference: ref,
+			})
+		}
 		return
 	}
 

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -302,18 +302,22 @@ func TestAnchorInternalCaseMismatch(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
-func TestAnchorInternalHashDefault(t *testing.T) {
-	// fails for # href when not asked
+func TestAnchorInternalHashBlankDefault(t *testing.T) {
+	// fails for href="#" when not asked
 	hT := tTestFile("fixtures/links/hash_href.html")
 	tExpectIssue(t, hT, "empty hash", 1)
 	tExpectIssueCount(t, hT, 1)
 }
 
-func TestAnchorInternalHashOption(t *testing.T) {
-	// passes for # href when asked
-	t.Skip("Not yet implemented")
-	hT := tTestFile("fixtures/links/hash_href.html")
-	tExpectIssueCount(t, hT, 0)
+func TestAnchorInternalHashBlankOption(t *testing.T) {
+	// passes for href="#" when asked, see
+	// https://github.com/wjdp/htmltest/issues/30
+	hT1 := tTestFileOpts("fixtures/links/hash_href.html",
+		map[string]interface{}{"CheckInternalHash": false})
+	tExpectIssueCount(t, hT1, 0)
+	hT2 := tTestFileOpts("fixtures/links/hash_href.html",
+		map[string]interface{}{"IgnoreInternalEmptyHash": true})
+	tExpectIssueCount(t, hT2, 0)
 }
 
 func TestAnchorInternalHashWeird(t *testing.T) {

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	IgnoreURLs []interface{}
 	IgnoreDirs []interface{}
 
+	IgnoreInternalEmptyHash             bool
 	IgnoreCanonicalBrokenLinks          bool
 	IgnoreAltMissing                    bool
 	IgnoreDirectoryMissingTrailingSlash bool
@@ -87,6 +88,7 @@ func DefaultOptions() map[string]interface{} {
 		"IgnoreURLs": []interface{}{},
 		"IgnoreDirs": []interface{}{},
 
+		"IgnoreInternalEmptyHash":             false,
 		"IgnoreCanonicalBrokenLinks":          true,
 		"IgnoreAltMissing":                    false,
 		"IgnoreDirectoryMissingTrailingSlash": false,


### PR DESCRIPTION
Ignore `href="#"` via:
- turning off `CheckInternalHash`
- turning on `IgnoreInternalEmptyHash`

See https://github.com/wjdp/htmltest/issues/30