### PR TITLE
CLI wrangling, add some options, fix some bugs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ install:
 script:
 - ./coverage.sh   # Run test suite with coverage reporting
 - go build -ldflags "-X main.buildDate=`date -u +%Y-%m-%dT%H:%M:%SZ`" -o bin/htmltest-$TRAVIS_OS_NAME -x main.go
-- bin/htmltest-$TRAVIS_OS_NAME -h         # Print usage
-- bin/htmltest-$TRAVIS_OS_NAME --version  # Print version
-- bin/htmltest-$TRAVIS_OS_NAME --conf htmldoc/fixtures/conf.yaml # Run
+- bin/htmltest-$TRAVIS_OS_NAME -h  # Print usage
+- bin/htmltest-$TRAVIS_OS_NAME -v  # Print version
+- bin/htmltest-$TRAVIS_OS_NAME -c htmldoc/fixtures/conf.yaml -l0 # Run
 
 after_success:
 - bash <(curl -s https://codecov.io/bash) # Report coverage to codecov

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -1,9 +1,11 @@
 package htmltest
 
 import (
+	"fmt"
 	"github.com/imdario/mergo"
 	"github.com/wjdp/htmltest/issues"
 	"path"
+	"reflect"
 	"regexp"
 	"strings"
 )
@@ -125,6 +127,17 @@ func (hT *HTMLTest) setOptions(optsUser map[string]interface{}) {
 	hT.opts = Options{}
 	mergo.MapWithOverwrite(&hT.opts, optsMap)
 
+	// If debug dump the options struct
+	if hT.opts.LogLevel == issues.LevelDebug {
+		s := reflect.ValueOf(&hT.opts).Elem()
+		typeOfT := s.Type()
+
+		for i := 0; i < s.NumField(); i++ {
+			f := s.Field(i)
+			fmt.Printf("%d: %s %s = %v\n", i,
+				typeOfT.Field(i).Name, f.Type(), f.Interface())
+		}
+	}
 }
 
 // InList tests if key is in a slice/list.

--- a/output/print.go
+++ b/output/print.go
@@ -1,0 +1,16 @@
+package output
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+)
+
+func Warn(a ...interface{}) {
+	color.Set(color.FgYellow)
+	fmt.Println(a...)
+	color.Unset()
+}
+
+func Debug(a ...interface{}) {
+	fmt.Println(a...)
+}


### PR DESCRIPTION
This is a bit multi-faceted due a number of small additions showcasing a bug, which then was squished using new debug viewing features.

- Add short versions of --log-level, --conf and --version, -l, -c and -v.

- Merge CLI options with config file options, CLI options take presidence.

- Add -s, --skip-external option. Disables CheckExternal, rather useful when running locally and calling many times.

- Improve error messages when config file is specified but not found, prior it would complain that a path or generic config file did not exist not very useful!

- When LogLevel is debug (0) the options struct gets dumped to output. Rather useful when debugging options resolution:

```
htmltest started at 06:07:10 on htmldoc/fixtures/documents
========================================================================
0: DirectoryPath string = htmldoc/fixtures/documents
1: FilePath string = 
2: CheckAnchors bool = true
3: CheckLinks bool = true
4: CheckImages bool = true
5: CheckScripts bool = true
6: CheckMeta bool = true
7: CheckGeneric bool = true
8: CheckExternal bool = true
9: CheckInternal bool = true
10: CheckInternalHash bool = true
11: CheckMailto bool = true
12: CheckTel bool = true
13: CheckFavicon bool = false
14: CheckMetaRefresh bool = true
15: EnforceHTTPS bool = false
16: IgnoreURLs []interface {} = []
17: IgnoreDirs []interface {} = []
18: IgnoreInternalEmptyHash bool = false
19: IgnoreCanonicalBrokenLinks bool = true
20: IgnoreAltMissing bool = false
21: IgnoreDirectoryMissingTrailingSlash bool = false
22: IgnoreTagAttribute string = data-proofer-ignore
23: TestFilesConcurrently bool = false
24: DocumentConcurrencyLimit int = 128
25: HTTPConcurrencyLimit int = 16
26: LogLevel int = 0
27: LogSort string = document
28: DirectoryIndex string = index.html
29: ExternalTimeout int = 15
30: StripQueryString bool = true
31: StripQueryExcludes []string = [fonts.googleapis.com]
32: EnableCache bool = true
33: EnableLog bool = true
34: ProgDir string = tmp/.htmltest
35: CacheFile string = refcache.json
36: LogFile string = htmltest.log
37: CacheExpires string = 336h
38: NoRun bool = false
```

- Fixed a bug where specifying --log-level caused unexpected crashes. Was due to not sanitising the input before assuming it's an int.

- Add opttions/print.go, has Warn and Debug functions for those respective outputs.