### PR TITLE
Further CLI wrangling, allow both file and dir as <path>, extra stats.

### DIFF
--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -187,3 +187,8 @@ func (hT *HTMLTest) postChecks(document *htmldoc.Document) {
 func (hT *HTMLTest) CountErrors() int {
 	return hT.issueStore.Count(issues.LevelError)
 }
+
+// CountDocuments : Return number of documents in hT document store
+func (hT *HTMLTest) CountDocuments() int {
+	return len(hT.documentStore.Documents)
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ const cmdSeparator string = "===================================================
 
 var (
 	buildDate string
+	fileMode  bool
 )
 
 func main() {
@@ -119,11 +120,12 @@ func augmentWithCLIArgs(options optsMap, arguments map[string]interface{}) {
 		if fi.IsDir() {
 			// We have a directory
 			options["DirectoryPath"] = path.Clean(arguments["<path>"].(string))
+			fileMode = false
 		} else {
 			// We have a file
 			options["DirectoryPath"] = path.Dir(arguments["<path>"].(string))
 			options["FilePath"] = path.Base(arguments["<path>"].(string))
-
+			fileMode = true
 		}
 
 	}
@@ -157,7 +159,9 @@ func run(options optsMap) int {
 	if numErrors == 0 {
 		color.Set(color.FgHiGreen)
 		fmt.Println("✔✔✔ passed in", timeEnd.Sub(timeStart))
-		fmt.Println("tested", hT.CountDocuments(), "documents")
+		if !fileMode {
+			fmt.Println("tested", hT.CountDocuments(), "documents")
+		}
 		color.Unset()
 		return 0
 	}
@@ -165,7 +169,11 @@ func run(options optsMap) int {
 	color.Set(color.FgHiRed)
 	fmt.Println(cmdSeparator)
 	fmt.Println("✘✘✘ failed in", timeEnd.Sub(timeStart))
-	fmt.Println(numErrors, "errors in", hT.CountDocuments(), "documents")
+	if fileMode {
+		fmt.Println(numErrors, "errors")
+	} else {
+		fmt.Println(numErrors, "errors in", hT.CountDocuments(), "documents")
+	}
 	color.Unset()
 	return 1
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+	"path"
 	"strconv"
 	"time"
 )
@@ -69,7 +70,8 @@ func parseConfFile(arguments map[string]interface{}, path string, explicit bool)
 
 	if os.IsNotExist(err) {
 		if explicit {
-			output.AbortWith("The provided config file: ", path, "does not exist.")
+			output.AbortWith("Cannot access config file '" + path +
+				"', no such file.")
 		} else {
 			output.AbortWith(`No path provided & the default config .htmltest.yml does not exist.
 See htmltest -h for usage.`)
@@ -98,8 +100,32 @@ func parseCLIArgs(arguments map[string]interface{}) optsMap {
 func augmentWithCLIArgs(options optsMap, arguments map[string]interface{}) {
 	// Deal with cli arguments
 
+	// We've been given a path, check it exists and decide if it's a single
+	// file or a directory of files to check.
 	if arguments["<path>"] != nil {
-		options["DirectoryPath"] = arguments["<path>"]
+		// Open <path>
+		f, err := os.Open(path.Clean(arguments["<path>"].(string)))
+		if os.IsNotExist(err) {
+			output.AbortWith("Cannot access '" + arguments["<path>"].(string) +
+				"', no such file or directory.")
+		}
+		output.CheckErrorGeneric(err)
+		defer f.Close()
+
+		// Get FileInfo, (scan for details)
+		fi, err := f.Stat()
+		output.CheckErrorPanic(err)
+
+		if fi.IsDir() {
+			// We have a directory
+			options["DirectoryPath"] = path.Clean(arguments["<path>"].(string))
+		} else {
+			// We have a file
+			options["DirectoryPath"] = path.Dir(arguments["<path>"].(string))
+			options["FilePath"] = path.Base(arguments["<path>"].(string))
+
+		}
+
 	}
 
 	if arguments["--log-level"] != nil {
@@ -131,6 +157,7 @@ func run(options optsMap) int {
 	if numErrors == 0 {
 		color.Set(color.FgHiGreen)
 		fmt.Println("✔✔✔ passed in", timeEnd.Sub(timeStart))
+		fmt.Println("tested", hT.CountDocuments(), "documents")
 		color.Unset()
 		return 0
 	}
@@ -138,7 +165,7 @@ func run(options optsMap) int {
 	color.Set(color.FgHiRed)
 	fmt.Println(cmdSeparator)
 	fmt.Println("✘✘✘ failed in", timeEnd.Sub(timeStart))
-	fmt.Println(numErrors, "errors")
+	fmt.Println(numErrors, "errors in", hT.CountDocuments(), "documents")
 	color.Unset()
 	return 1
 


### PR DESCRIPTION
- Allow passing a file in as <path> from the CL. Detect file/dir in main.go and pass correct options to htmltest.

```
~/g/s/g/w/htmltest ❯❯❯ go run main.go htmltest/fixtures/meta/refresh-internal-broken.html -s                                                   cli-wrangling ◼
Skipping the checking of external links.
htmltest started at 05:41:53 on htmltest/fixtures/meta
========================================================================
refresh-internal-broken.html
  target does not exist --- refresh-internal-broken.html --> nope.html
========================================================================
✘✘✘ failed in 644.93µs
1 errors in 12 documents
```

- Add CountDocuments func to htmltest, allows passthru of doumentStore count for CLI stats. Print CountDocuments in pass and fail messages.

```
1 errors in 12 documents
3 documents tested
```

- Further cleanup of CLI errors in main.go