### PR TITLE
Implement document type checking (DOCTYPE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Many options of the following tests can customised. Items marked :soon: are not 
 - `meta`: Whether refresh tags are valid and the url works.
 - `meta`: :soon: Whether images and URLs in the OpenGraph metadata are valid.
 - `meta` `title`: :soon: Whether you've got the [recommended tags](https://support.google.com/webmasters/answer/79812?hl=en) in your head.
+- 'DOCTYPE': Whether a doctype is correctly specified.
 
 ### What's Not
 
@@ -87,6 +88,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | :----- | :---------- | :------ |
 | `DirectoryPath` | Directory to scan for HTML files. | |
 | `FilePath` | File to scan, omit if using `DirectoryPath`. | |
+| `CheckDoctype` | Enables checking the document type declaration. | `true` |
 | `CheckAnchors` | Enables checking `<a…` tags. | `true` |
 | `CheckLinks` | Enables checking `<link…` tags. | `true` |
 | `CheckImages` | Enables checking `<img…` tags | `true` |
@@ -100,6 +102,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `CheckTel` | Enables–albeit quite basic–`tel:` link checking. | `true` |
 | `CheckFavicon` | Enables favicon checking, ensures every page has a favicon set. | `false` |
 | `CheckMetaRefresh` | Enables checking meta refresh tags. | `true` |
+| `EnforceHTML5` | Fails when the doctype isn't `<!DOCTYPE html>`. | `false` |
 | `EnforceHTTPS` | Fails when encountering an `http://` link. Useful to prevent mixed content errors when serving over HTTPS. | `false` |
 | `IgnoreURLs` | Array of regexs of URLs to ignore. | empty |
 | `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files. | empty |

--- a/htmldoc/fixtures/conf.yaml
+++ b/htmldoc/fixtures/conf.yaml
@@ -1,1 +1,2 @@
 DirectoryPath: "htmldoc/fixtures/documents"
+CheckDoctype: false

--- a/htmldoc/fixtures/documents/dir2/index.html
+++ b/htmldoc/fixtures/documents/dir2/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/htmltest/check-doctype.go
+++ b/htmltest/check-doctype.go
@@ -1,0 +1,41 @@
+package htmltest
+
+import (
+	"fmt"
+	"github.com/wjdp/htmltest/htmldoc"
+	"github.com/wjdp/htmltest/issues"
+)
+
+func (hT *HTMLTest) checkDoctype(document *htmldoc.Document) {
+	// Error if no doctype
+	// The doctype *must* be the first element in the document
+	// If it's not golang.org/x/net/html simply ignores it.
+	if document.DoctypeNode == nil {
+		hT.issueStore.AddIssue(issues.Issue{
+			Level:    issues.LevelError,
+			Message:  "missing doctype",
+			Document: document,
+		})
+		return
+	}
+
+	// Dump the doctype data and attrs to debug
+	hT.issueStore.AddIssue(issues.Issue{
+		Level: issues.LevelDebug,
+		Message: fmt.Sprintf("DOCTYPE %+v %+v\n",
+			document.DoctypeNode.Data, document.DoctypeNode.Attr),
+		Document: document,
+	})
+
+	isHTML5 := (document.DoctypeNode.Data == "html" &&
+		len(document.DoctypeNode.Attr) == 0)
+
+	if hT.opts.EnforceHTML5 && !isHTML5 {
+		hT.issueStore.AddIssue(issues.Issue{
+			Level:    issues.LevelError,
+			Message:  "doctype isn't html5",
+			Document: document,
+		})
+	}
+
+}

--- a/htmltest/check-doctype_test.go
+++ b/htmltest/check-doctype_test.go
@@ -1,0 +1,49 @@
+package htmltest
+
+import (
+	"testing"
+)
+
+// Passes for valid doctype
+func TestDoctypeValid(t *testing.T) {
+	hT1 := tTestFileOpts("fixtures/doctype/doctype-html5.html",
+		map[string]interface{}{"CheckDoctype": true})
+	tExpectIssueCount(t, hT1, 0)
+	hT2 := tTestFileOpts("fixtures/doctype/doctype-html4.html",
+		map[string]interface{}{"CheckDoctype": true})
+	tExpectIssueCount(t, hT2, 0)
+	hT3 := tTestFileOpts("fixtures/doctype/doctype-xhtml.html",
+		map[string]interface{}{"CheckDoctype": true})
+	tExpectIssueCount(t, hT3, 0)
+}
+
+// Fails for missing doctype
+func TestDoctypeMissing(t *testing.T) {
+	hT := tTestFileOpts("fixtures/doctype/doctype-missing.html",
+		map[string]interface{}{"CheckDoctype": true})
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "missing doctype", 1)
+}
+
+// Fails for a doctype mixed in with page
+func TestDoctypeNotFirst(t *testing.T) {
+	hT := tTestFileOpts("fixtures/doctype/doctype-not-first.html",
+		map[string]interface{}{"CheckDoctype": true})
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "missing doctype", 1)
+}
+
+// Passes for html5 doctype when asked
+func TestDoctypeHTML5Valid(t *testing.T) {
+	hT := tTestFileOpts("fixtures/doctype/doctype-html5.html",
+		map[string]interface{}{"CheckDoctype": true, "EnforceHTML5": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
+// Fails for other doctype when asked for html5
+func TestDoctypeHTML5Invalid(t *testing.T) {
+	hT := tTestFileOpts("fixtures/doctype/doctype-html4.html",
+		map[string]interface{}{"CheckDoctype": true, "EnforceHTML5": true})
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "doctype isn't html5", 1)
+}

--- a/htmltest/fixtures/doctype/doctype-html4.html
+++ b/htmltest/fixtures/doctype/doctype-html4.html
@@ -1,0 +1,1 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">

--- a/htmltest/fixtures/doctype/doctype-html5.html
+++ b/htmltest/fixtures/doctype/doctype-html5.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/htmltest/fixtures/doctype/doctype-missing.html
+++ b/htmltest/fixtures/doctype/doctype-missing.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>IMA PAGE!</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/doctype/doctype-not-first.html
+++ b/htmltest/fixtures/doctype/doctype-not-first.html
@@ -1,0 +1,9 @@
+<html>
+<!DOCTYPE html>
+<head>
+    <title></title>
+</head>
+<body>
+
+</body>
+</html>

--- a/htmltest/fixtures/doctype/doctype-xhtml.html
+++ b/htmltest/fixtures/doctype/doctype-xhtml.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -120,6 +120,11 @@ func (hT *HTMLTest) testDocuments() {
 
 func (hT *HTMLTest) testDocument(document *htmldoc.Document) {
 	document.Parse()
+
+	if hT.opts.CheckDoctype {
+		hT.checkDoctype(document)
+	}
+
 	for _, n := range document.NodesOfInterest {
 		switch n.Data {
 		case "a":

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	DirectoryPath string
 	FilePath      string
 
+	CheckDoctype bool
 	CheckAnchors bool
 	CheckLinks   bool
 	CheckImages  bool
@@ -31,6 +32,7 @@ type Options struct {
 	CheckFavicon      bool
 	CheckMetaRefresh  bool
 
+	EnforceHTML5 bool
 	EnforceHTTPS bool
 
 	IgnoreURLs []interface{}
@@ -70,6 +72,7 @@ type Options struct {
 func DefaultOptions() map[string]interface{} {
 	// Specify defaults here
 	return map[string]interface{}{
+		"CheckDoctype": true,
 		"CheckAnchors": true,
 		"CheckLinks":   true,
 		"CheckImages":  true,
@@ -85,6 +88,7 @@ func DefaultOptions() map[string]interface{} {
 		"CheckFavicon":      false,
 		"CheckMetaRefresh":  true,
 
+		"EnforceHTML5": false,
 		"EnforceHTTPS": false,
 
 		"IgnoreURLs": []interface{}{},

--- a/htmltest/test_helpers_test.go
+++ b/htmltest/test_helpers_test.go
@@ -38,6 +38,7 @@ func tTestFile(filename string) *HTMLTest {
 		"ExternalTimeout": tExternalTimeout,
 		"EnableCache":     false,
 		"EnableLog":       false,
+		"CheckDoctype":    false,
 	}
 	return Test(opts)
 }
@@ -50,6 +51,7 @@ func tTestFileOpts(filename string, tOpts map[string]interface{}) *HTMLTest {
 		"ExternalTimeout": tExternalTimeout,
 		"EnableCache":     false,
 		"EnableLog":       false,
+		"CheckDoctype":    false,
 	}
 	mergo.MergeWithOverwrite(&opts, tOpts)
 	return Test(opts)
@@ -62,6 +64,7 @@ func tTestDirectory(filename string) *HTMLTest {
 		"ExternalTimeout": tExternalTimeout,
 		"EnableCache":     false,
 		"EnableLog":       false,
+		"CheckDoctype":    false,
 	}
 	return Test(opts)
 }
@@ -73,6 +76,7 @@ func tTestDirectoryOpts(filename string, tOpts map[string]interface{}) *HTMLTest
 		"ExternalTimeout": tExternalTimeout,
 		"EnableCache":     false,
 		"EnableLog":       false,
+		"CheckDoctype":    false,
 	}
 	mergo.MergeWithOverwrite(&opts, tOpts)
 	return Test(opts)

--- a/issues/issue_store.go
+++ b/issues/issue_store.go
@@ -3,6 +3,7 @@ package issues
 
 import (
 	"fmt"
+	"github.com/fatih/color"
 	"github.com/wjdp/htmltest/htmldoc"
 	"io/ioutil"
 	"strings"
@@ -92,6 +93,11 @@ func (iS *IssueStore) MessageMatchCount(substr string) int {
 // that document's SitePath. Respects log level.
 func (iS *IssueStore) PrintDocumentIssues(doc *htmldoc.Document) {
 	if iS.CountByDoc(iS.logLevel, doc) == 0 {
+		if iS.logLevel == LevelDebug {
+			color.Set(color.FgMagenta)
+			fmt.Println(doc.SitePath)
+			color.Unset()
+		}
 		return
 	}
 	iS.storeMutex.RLock()


### PR DESCRIPTION
- New options: CheckDoctype and EnforceHTML5

- When CheckDoctype is true we check that a doctype exists.
- When EnforceHTML5 is true we check the doctype matches the format for HTML5.

The golang htmlpackage does most of the heavy lifting for this one. For example it ignores doctypes which are not the first node in the document.