### PR TITLE
Add FileExtension option, defaults to ".html"

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `DirectoryPath` | Directory to scan for HTML files. | |
 | `DirectoryIndex` | The file to look for when linking to a directory. | `index.html` |
 | `FilePath` | Single file to test within `DirectoryPath`, omit to test all. | |
+| `FileExtension` | Extension of your HTML documents, includes the dot. If `FilePath` is set we use the extension from that. | `.html` |
 | `CheckDoctype` | Enables checking the document type declaration. | `true` |
 | `CheckAnchors` | Enables checking `<a…` tags. | `true` |
 | `CheckLinks` | Enables checking `<link…` tags. | `true` |

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -29,6 +29,11 @@ type HTMLTest struct {
 func Test(optsUser map[string]interface{}) *HTMLTest {
 	hT := HTMLTest{}
 
+	// If FilePath set, modify FileExtension
+	if optsUser["FilePath"] != nil {
+		optsUser["FileExtension"] = path.Ext(optsUser["FilePath"].(string))
+	}
+
 	// Merge user options with defaults and set hT.opts
 	hT.setOptions(optsUser)
 
@@ -63,7 +68,7 @@ func Test(optsUser map[string]interface{}) *HTMLTest {
 	hT.documentStore = htmldoc.NewDocumentStore()
 	// Setup document store
 	hT.documentStore.BasePath = hT.opts.DirectoryPath
-	hT.documentStore.DocumentExtension = ".html" // TODO add option
+	hT.documentStore.DocumentExtension = hT.opts.FileExtension
 	hT.documentStore.DirectoryIndex = hT.opts.DirectoryIndex
 	hT.documentStore.IgnorePatterns = hT.opts.IgnoreDirs
 	// Discover documents

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	DirectoryPath  string
 	DirectoryIndex string
 	FilePath       string
+	FileExtension  string
 
 	CheckDoctype bool
 	CheckAnchors bool
@@ -72,6 +73,7 @@ func DefaultOptions() map[string]interface{} {
 	// Specify defaults here
 	return map[string]interface{}{
 		"DirectoryIndex": "index.html",
+		"FileExtension":  ".html",
 
 		"CheckDoctype": true,
 		"CheckAnchors": true,


### PR DESCRIPTION
- Allow custom file extension via `FileExtension` option.

- When FilePath is set extract and use file extension from that.