### PR TITLE
Refactor/small

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you generate HTML files, [html-proofer](https://github.com/gjtorikian/html-pr
 
 :horse_racing: *Faster?* Yep, quite a bit actually. On [a site](https://github.com/newtheatre/history-project) with over 2000 files htmlproofer took over [three minutes](https://travis-ci.org/newtheatre/history-project#L564), htmltest took [8.6 seconds](https://travis-ci.org/newtheatre/history-project#L538). Both tools had full valid caches.
 
-:confused: *Why make another tool*: A mix of frustration with using htmlproofer/Ruby on large sites and needing a good project to learn Go with. Yep, this is my first major Go program, it uses pretty much the same spec/tests as htmlproofer so should be accurate, but probably could do with some refactoring.
+:confused: *Why make another tool*: A mix of frustration with using htmlproofer/Ruby on large sites and needing a good project to get to grips with Go.
 
 ## :floppy_disk: Installation
 
@@ -57,7 +57,7 @@ Many options of the following tests can customised. Items marked :soon: are not 
 - `meta`: Whether refresh tags are valid and the url works.
 - `meta`: :soon: Whether images and URLs in the OpenGraph metadata are valid.
 - `meta` `title`: :soon: Whether you've got the [recommended tags](https://support.google.com/webmasters/answer/79812?hl=en) in your head.
-- 'DOCTYPE': Whether a doctype is correctly specified.
+- `DOCTYPE`: Whether a doctype is correctly specified.
 
 ### What's Not
 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-go build -ldflags "-X main.buildDate=`date -u +%Y-%m-%dT%H:%M:%SZ`" -o bin/htmltest -x main.go
+# Script for devs to build a copy of the app with build flags set
+
+go build -ldflags "-X main.buildDate=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/htmltest -x main.go

--- a/htmldoc/reference.go
+++ b/htmldoc/reference.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"github.com/wjdp/htmltest/output"
 )
 
 // Reference struct, representation of the link between a document and a
@@ -30,9 +31,7 @@ func NewReference(document *Document, node *html.Node, path string) *Reference {
 	}
 	// Parse and store parsed URL
 	u, err := url.Parse(path)
-	if err != nil {
-		panic(err)
-	}
+	output.CheckErrorPanic(err)
 	ref.URL = u
 	return &ref
 }

--- a/issues/issue_store.go
+++ b/issues/issue_store.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"sync"
+	"github.com/wjdp/htmltest/output"
 )
 
 // IssueStore : store of htmltest issues.
@@ -112,9 +113,7 @@ func (iS *IssueStore) PrintDocumentIssues(doc *htmldoc.Document) {
 // given in NewIssueStore.
 func (iS *IssueStore) WriteLog(path string) {
 	err := ioutil.WriteFile(path, iS.byteLog, 0644)
-	if err != nil {
-		panic(err)
-	}
+	output.CheckErrorPanic(err)
 }
 
 // DumpIssues : Dump all issues to stdout, called by test helpers when issue

--- a/refcache/refcache.go
+++ b/refcache/refcache.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"sync"
 	"time"
+	"github.com/wjdp/htmltest/output"
 )
 
 // RefCache struct : store of cached references.
@@ -36,7 +37,7 @@ func (rS *RefCache) ReadStore(storePath string) bool {
 	f, err := os.Open(storePath)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			panic(err)
+			output.CheckErrorPanic(err)
 		}
 		return false
 	}
@@ -44,9 +45,7 @@ func (rS *RefCache) ReadStore(storePath string) bool {
 
 	var refStore map[string]CachedRef
 	err = json.NewDecoder(f).Decode(&refStore)
-	if err != nil {
-		panic(err)
-	}
+	output.CheckErrorPanic(err)
 
 	rS.refStore = refStore
 	return true
@@ -57,15 +56,11 @@ func (rS *RefCache) WriteStore(storePath string) {
 	// Write out RefCache
 	os.MkdirAll(path.Dir(storePath), 0777)
 	f, err := os.Create(storePath)
-	if err != nil {
-		panic(err)
-	}
+	output.CheckErrorPanic(err)
 	defer f.Close()
 
 	err = json.NewEncoder(f).Encode(&rS.refStore)
-	if err != nil {
-		panic(err)
-	}
+	output.CheckErrorPanic(err)
 }
 
 // CachedRef struct : Single cached result


### PR DESCRIPTION
- Update build.sh
- Small README cleanup / fixes
- Use output.CheckErrorPanic instead of if err != nil { panic }. We had both, one or other.