### PR TITLE
Update TLS conf to actually disable H2

### DIFF
--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -128,6 +128,14 @@ func TestAnchorExternalHTTPSInvalid(t *testing.T) {
 	tExpectIssueCount(t, hT, 6)
 }
 
+func TestAnchorExternalHTTPSBadH2(t *testing.T) {
+	// should connect to servers with bad http/2 support
+	// See issue #49
+	tSkipShortExternal(t)
+	hT := tTestFile("fixtures/links/https-valid-h2.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorExternalMissingProtocolValid(t *testing.T) {
 	// works for valid links missing the protocol
 	tSkipShortExternal(t)

--- a/htmltest/fixtures/links/https-valid-h2.html
+++ b/htmltest/fixtures/links/https-valid-h2.html
@@ -1,0 +1,11 @@
+<html>
+
+<body>
+    <a href="https://f5.com/">F5, the people who make BIG/IP, which can't do HTTP/2 very well</a>
+    <a href="https://www.southampton.ac.uk/">Southampton Uni, who use BIG/IP and therefore cannot do HTTP/2 very well</a>
+    <a href="https://www.southampton.ac.uk/">Southampton Uni, who use BIG/IP and therefore cannot do HTTP/2 very well</a>
+
+    <a href="https://www.linkedin.com/">LinkedIn does not seem to support APLN.</a>
+</body>
+
+</html>


### PR DESCRIPTION
Go's HTTP lib wil negotiate HTTP/2 with a server, but then cannot fall back to H1 if H2 is having issues. Turn of H2, we don't really mind.

Will close #49 