### PR TITLE
Ignore links with rel=dns-prefetch

### DIFF
--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -28,6 +28,12 @@ func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 		document.State.FaviconPresent = true
 	}
 
+	// Ignore if rel=dns-prefetch, see #40. If we have more cases like this a hashable type should be created and
+	// checked against.
+	if attrs["rel"] == "dns-prefetch" {
+		return
+	}
+
 	// Create reference
 	ref := htmldoc.NewReference(document, node, attrs["href"])
 

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -438,6 +438,12 @@ func TestLinkHrefBrokenCanonicalOption(t *testing.T) {
 	tExpectIssueCount(t, hT, 1)
 }
 
+func TestLinkRelDnsPrefetch(t *testing.T) {
+	// ignores links with rel="dns-prefetch"
+	hT := tTestFile("fixtures/links/link-rel-dns-prefetch.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorPre(t *testing.T) {
 	// works for broken anchors within pre & code
 	hT := tTestFile("fixtures/links/anchors_in_pre.html")

--- a/htmltest/fixtures/links/link-rel-dns-prefetch.html
+++ b/htmltest/fixtures/links/link-rel-dns-prefetch.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com/">
+</head>
+<body>
+    <p>This page has a hint asking the browser to prefetch the DNS query for fonts.googleapis.com</p>
+</body>
+</html>


### PR DESCRIPTION
Will close #40 

Our current behaviour for checking these links is incorrect. If we were to implement anything it would check the link is formed correctly and DNS resolves for it. No HTTP checks should take place.

In lieu of that for now we disable checks running against these links.

- [x] Brew