### PR TITLE
Add AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+environment:
+  GOPATH: C:\GOPATH
+  GOARCH: amd64
+
+init:
+  - set PATH=%PATH%;%GOPATH%\bin
+  - go version
+  - go env
+
+# clones and cd's to path
+clone_folder: C:\GOPATH\src\github.com\wjdp\htmltest
+
+install:
+  - go get -t ./... # Fetch all dependencies
+
+build_script:
+  - go test -v -race ./... # Run test suite
+  - cmd: for /f %%i in ('"call powershell (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd-hh:mm:ssZ')"') do set BUILD_DATE=%%i
+  - cmd: for /f %%i in ('"call git describe --tags"') do set VERSION=%%i
+  - cmd: go build -ldflags "-X main.buildDate=%BUILD_DATE% -X main.version=%VERSION%" -o bin/htmltest-%GOARCH%.exe -x main.go
+  - cmd: .\bin\htmltest-%GOARCH%.exe -h  # Print usage
+  - cmd: .\bin\htmltest-%GOARCH%.exe -v  # Print version
+  - cmd: .\bin\htmltest-%GOARCH%.exe -c htmldoc/fixtures/conf.yaml -l0 # Run config
+  - cmd: .\bin\htmltest-%GOARCH%.exe htmldoc/fixtures/documents/dir1 # Run on dir
+  - cmd: .\bin\htmltest-%GOARCH%.exe htmltest/fixtures/links/head_link_href.html # Run on file
+
+artifacts:
+  - path: bin\*.exe
+    name: htmltest-binaries
+
+deploy:
+  provider: GitHub
+  auth_token:
+      secure: 7ijatuctLTwV3xu0FAyCHjcupsNxqfv3MVfDLB2bUeoRwyy+rGJmF2JsQDP2h6ya # your encrypted token from GitHub
+  artifact: htmltest-binaries
+  on:
+    appveyor_repo_tag: true        # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ artifacts:
 deploy:
   provider: GitHub
   auth_token:
-      secure: 7ijatuctLTwV3xu0FAyCHjcupsNxqfv3MVfDLB2bUeoRwyy+rGJmF2JsQDP2h6ya # your encrypted token from GitHub
+      secure: 9+xdNIvrnAVRoTFYPvdfYxnSUtWXObdc4DUIndJwiliSsD44stBnDwCvPZ+3OH3e # your encrypted token from GitHub
   artifact: htmltest-binaries
   on:
     appveyor_repo_tag: true        # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   GOPATH: C:\GOPATH
   GOARCH: amd64
+  OS_NAME: win64
 
 init:
   - set PATH=%PATH%;%GOPATH%\bin
@@ -17,12 +18,12 @@ build_script:
   - go test -v -race ./... # Run test suite
   - cmd: for /f %%i in ('"call powershell (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd-hh:mm:ssZ')"') do set BUILD_DATE=%%i
   - cmd: for /f %%i in ('"call git describe --tags"') do set VERSION=%%i
-  - cmd: go build -ldflags "-X main.buildDate=%BUILD_DATE% -X main.version=%VERSION%" -o bin/htmltest-%GOARCH%.exe -x main.go
-  - cmd: .\bin\htmltest-%GOARCH%.exe -h  # Print usage
-  - cmd: .\bin\htmltest-%GOARCH%.exe -v  # Print version
-  - cmd: .\bin\htmltest-%GOARCH%.exe -c htmldoc/fixtures/conf.yaml -l0 # Run config
-  - cmd: .\bin\htmltest-%GOARCH%.exe htmldoc/fixtures/documents/dir1 # Run on dir
-  - cmd: .\bin\htmltest-%GOARCH%.exe htmltest/fixtures/links/head_link_href.html # Run on file
+  - cmd: go build -ldflags "-X main.buildDate=%BUILD_DATE% -X main.version=%VERSION%" -o bin/htmltest-%OS_NAME%.exe -x main.go
+  - cmd: .\bin\htmltest-%OS_NAME%.exe -h  # Print usage
+  - cmd: .\bin\htmltest-%OS_NAME%.exe -v  # Print version
+  - cmd: .\bin\htmltest-%OS_NAME%.exe -c htmldoc/fixtures/conf.yaml -l0 # Run config
+  - cmd: .\bin\htmltest-%OS_NAME%.exe htmldoc/fixtures/documents/dir1 # Run on dir
+  - cmd: .\bin\htmltest-%OS_NAME%.exe htmltest/fixtures/links/head_link_href.html # Run on file
 
 artifacts:
   - path: bin\*.exe


### PR DESCRIPTION
@wjdp thanks for great tool and blazing fast alternative to `html-proofer`!
I decided to take a look at what I can do with #18.
Ended up in working AppVeyor config with artifacts being released on tags builds to GitHub.

Here are the build logs: https://ci.appveyor.com/project/miltador/htmltest
And here is my test release of Windows build to proof it's working:
https://github.com/miltador-forks/htmltest/releases/tag/windows-builds

So this is it, please take a look and, if it's fine, consider the next steps:
- [x] change auth_token to yours (instructions: https://www.appveyor.com/docs/deployment/github/)
- [x] enable AppVeyor 😊

Closes #18.