### PR TITLE
Improve coverage reporting accuracy with -coverpkg

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
 set -e
-echo "" > coverage.txt
+echo "mode: atomic" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do
-    go test -v -race -coverprofile=profile.out -covermode=atomic $d
+    go test -v -race -coverprofile=profile.out -covermode=atomic -coverpkg=./... $d
     if [ -f profile.out ]; then
-        cat profile.out >> coverage.txt
+        grep -h -v "^mode:" profile.out >> coverage.txt
         rm profile.out
     fi
 done
+
+# Print out the coverage.txt file with a total value
+go tool cover -func=coverage.txt


### PR DESCRIPTION
Just running `go test -cover` will only report the coverage on files that are tested.

Using `go test -coverpkg=./...` the tests report their impact on the coverage of the project overall rather than just the covered file.
`go tool cover` command has also been added to view the coverage from within builds.

It is expected from my local testing that coverage will drop from 96.4% to 84.3%.

This is a contribution back based on an adaptation of this script for another project, the final line also allows coverage reporting in GitLab natively.