### PR TITLE
Allow linking directly to index.html without a trailing slash

### DIFF
--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -254,8 +254,10 @@ func (hT *HTMLTest) checkInternal(ref *htmldoc.Reference) {
 	refDoc, refExists := hT.documentStore.ResolveRef(ref)
 
 	if refExists {
-		// If path doesn't end in slash and the resolved ref is an index.html, complain
-		if (ref.URL.Path[len(ref.URL.Path)-1] != '/') && (path.Base(refDoc.SitePath) == hT.opts.DirectoryIndex) && (!hT.opts.IgnoreDirectoryMissingTrailingSlash) {
+		// If the resolved ref is an index.html and the path doesn't end in a
+		// trailing slash (and isn't linking directly to the index), complain.
+		if !hT.opts.IgnoreDirectoryMissingTrailingSlash && path.Base(refDoc.SitePath) == hT.opts.DirectoryIndex &&
+			!strings.HasSuffix(ref.URL.Path, hT.opts.DirectoryIndex) && !strings.HasSuffix(ref.URL.Path, "/") {
 			hT.issueStore.AddIssue(issues.Issue{
 				Level:     issues.LevelError,
 				Message:   "target is a directory, href lacks trailing slash",

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -278,15 +278,21 @@ func TestAnchorDirectoryNoTrailingSlash(t *testing.T) {
 }
 
 func TestAnchorDirectoryNoTrailingSlashOption(t *testing.T) {
-	// fails for internal linking to a directory without trailing slash
+	// passes for internal linking to a directory without trailing slash when asked
 	hT := tTestFileOpts("fixtures/links/link_directory_without_slash.html",
 		map[string]interface{}{"IgnoreDirectoryMissingTrailingSlash": true})
 	tExpectIssueCount(t, hT, 0)
 }
 
 func TestAnchorDirectoryQueryHash(t *testing.T) {
-	// fails for internal linking to a directory without trailing slash
+	// passes for internal linking to a directory with trailing slash
 	hT := tTestFile("fixtures/links/link_directory_with_slash_query_hash.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
+func TestAnchorDirectoryRootExplicit(t *testing.T) {
+	// passes when linking explicitly to the directory root
+	hT := tTestFile("fixtures/links/root-link-explicit.html")
 	tExpectIssueCount(t, hT, 0)
 }
 

--- a/htmltest/fixtures/links/root-link-explicit.html
+++ b/htmltest/fixtures/links/root-link-explicit.html
@@ -1,0 +1,1 @@
+Hello I'm <a href="rootLink/index.html">explicitly linking</a> to the root document.


### PR DESCRIPTION
This completes #56!

Fix #55.