### PR TITLE
Don't complain if linking to ignored dir

### DIFF
--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -329,12 +329,15 @@ func (hT *HTMLTest) checkFile(ref *htmldoc.Reference, absPath string) bool {
 	output.CheckErrorPanic(err)
 
 	if f.IsDir() {
-		hT.issueStore.AddIssue(issues.Issue{
-			Level:     issues.LevelError,
-			Message:   "target is a directory, no index",
-			Reference: ref,
-		})
-		return false
+		f, err = os.Stat(path.Join(absPath, hT.opts.DirectoryIndex))
+		if os.IsNotExist(err) {
+			hT.issueStore.AddIssue(issues.Issue{
+				Level:     issues.LevelError,
+				Message:   "target is a directory, no index",
+				Reference: ref,
+			})
+			return false
+		}
 	}
 	return true
 }

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -256,6 +256,13 @@ func TestAnchorDirectoryRootResolve(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
+func TestAnchorDirectoryRootResolveWithIgnoredDir(t *testing.T) {
+	// ignoring the target of the link does not break
+	hT := tTestFileOpts("fixtures/links/linkToFolder.html",
+		map[string]interface{}{"IgnoreDirs": []interface{}{"folder"}})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorDirectoryCustomRoot(t *testing.T) {
 	// works for custom directory index file
 	t.Skip("Not yet implemented")


### PR DESCRIPTION
Previously, if "a.html" linked to an ignored directory "b", htmltest
would complain that "b" did not contain index.html, even if it did.