### PR TITLE
fix: ignore generic if data-proofer-ignore is iset

### DIFF
--- a/htmltest/check-generic.go
+++ b/htmltest/check-generic.go
@@ -2,6 +2,7 @@ package htmltest
 
 import (
 	"fmt"
+
 	"github.com/wjdp/htmltest/htmldoc"
 	"github.com/wjdp/htmltest/issues"
 	"golang.org/x/net/html"
@@ -11,6 +12,11 @@ import (
 func (hT *HTMLTest) checkGeneric(document *htmldoc.Document, node *html.Node, key string) {
 	// Fail silently if attribute isn't present
 	if !htmldoc.AttrPresent(node.Attr, key) {
+		return
+	}
+
+	// Ignore if data-proofer-ignore set
+	if htmldoc.AttrPresent(node.Attr, hT.opts.IgnoreTagAttribute) {
 		return
 	}
 

--- a/htmltest/check-generic_test.go
+++ b/htmltest/check-generic_test.go
@@ -1,9 +1,10 @@
 package htmltest
 
 import (
-	"github.com/wjdp/htmltest/issues"
 	"path"
 	"testing"
+
+	"github.com/wjdp/htmltest/issues"
 )
 
 var genericTests = []struct {
@@ -28,6 +29,7 @@ var genericTests = []struct {
 	{"embedMissing.html", 0},
 	{"iframeValid.html", 0},
 	{"iframeBroken.html", 1},
+	{"iframeBrokenButIgnored.html", 0},
 	{"iframeBlank.html", 2},
 	{"iframeMissing.html", 0},
 	{"inputSrcValid.html", 0},

--- a/htmltest/fixtures/generic/iframeBrokenButIgnored.html
+++ b/htmltest/fixtures/generic/iframeBrokenButIgnored.html
@@ -1,0 +1,3 @@
+<iframe src="nope.html" width="400" height="300" data-proofer-ignore>
+  <p>Your browser does not support iframes.</p>
+</iframe>


### PR DESCRIPTION
`data-proofer-ignore` was not being respected on iframes