### PR TITLE
Swap custom build with goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ main
 
 # builds
 bin/
+dist/
 
 # Cache dirs of program
 .htmltest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+project_name: htmltest
+
+git:
+  short_hash: true
+
+builds:
+  - binary: htmltest
+    main: ./main.go
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+
+archive:
+  replacements:
+    darwin: osx
+    linux: linux
+    windows: windows
+  format_overrides:
+    - goos: windows
+      format: zip
+
+release:
+  github:
+    owner: wjdp
+    name: htmltest
+
+  draft: true
+
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,13 +11,25 @@ builds:
       - darwin
       - linux
     goarch:
+      - 386
       - amd64
+      - arm
+      - arm64
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - Merge pull request
+    - Merge branch
 
 archive:
   replacements:
     darwin: osx
     linux: linux
     windows: windows
+    386: i386
+    amd64: amd64
   format_overrides:
     - goos: windows
       format: zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 script:
 - go test -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./... # Run test suite and generate coverage
 - go tool cover -func=coverage.txt  # Report coverage
-- go build -ldflags "-X main.buildDate=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/htmltest-$TRAVIS_OS_NAME -x main.go
+- go build -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/htmltest-$TRAVIS_OS_NAME -x main.go
 - bin/htmltest-$TRAVIS_OS_NAME -h  # Print usage
 - bin/htmltest-$TRAVIS_OS_NAME -v  # Print version
 - bin/htmltest-$TRAVIS_OS_NAME -c htmldoc/fixtures/conf.yaml -l0 # Run config
@@ -30,14 +30,14 @@ env:
   - secure: "H3SLwfn+szCdi2CmAsfbpHLYJBd0gvMR7Ik9oiJm+haY8+Y+BRDCFcb5CX6yiKsfJpQDM8sLLsF6t7nmiZVPAHx5q0ORExe5ddS6HhjvACeH7DnYCoHpDZaVr8DP6TPOZcHE2JWX2gdxI4Rg10bsnvxVbCYzoCjFFUD6ZXlPTJvkPQFQgCjLg0xfDxZloIpkYtkmheIjvBzkPXLygZzhNNq7BzhvY3CyYn4Gpda09woOSmar1ccVaVurzszlxD4fEIdKPapcS8MPXS2a7LPA8A0glr04aX75F3SHZQ/KtOU5jrNPxfyto+btTsAzoNytUFynPKXTLhkGgVnmLuixlTCVaB5KkMlKUE5MILwl4rDmzcs7jfXA/NIXl28oBw8+LHoFLEF27V+fSoRa8yulOCg4v2yvATZvtyK96QZ8bpT8hVvccVJDWDZZeEzQQlCfsB/ENjAeb7ryQjluZfivZMT3b6GpBmDTJxfeiBqRp+YYZiaB1XPTr87IQ68AIzhr6E+EPvENV4R5oFCUgaFtC5ptq86WSfHb2Iwy21sGf7tFho/jprjVsy6qtJ6qtizwOHT4IEahIAOk4Itj/7oLi2nL+qSj4ST/LFFdzQljTA7fy3ADB6xrDgE5Sr1prYd+uEuLmf1ZTHtiKBsvflJdbzPTwWU+qFO5wT1aWxo46+c="
 
 deploy:
-  - provider: script
+  - provider: script # Actual releases, uses goreleaser and xcompiles on a Linux box
     skip_cleanup: true
     script: curl -sL http://git.io/goreleaser | bash
     on:
       tags: true
       repo: wjdp/htmltest
       condition: $TRAVIS_OS_NAME = linux
-  - provider: s3
+  - provider: s3 # 'Snapshot' builds for every commit to master into s3 bucket
     access_key_id: AKIAIH2ZE2KZBNCVEGCA
     secret_access_key:
       secure: Rgwp7uzg/Uf9RYyOk2BNmUfEhdCk0843r0ndgxafNxSZu4SvXL5SgOvtulN4+aVOSAkyDwRpy645a2f8q4dl+idyQbLdn/U8/AIH3Q2vCPT3N/a4c74Ccf4yzIXzYoqRUuc0/DZKn7H6LNoDLBmdAQywVkf4EVA/hvIzr3qAj3kPjYJZtWSABWNSm4Zy03nobG8ONMOEJORGxJE9Kmnjpu2Jdita2rkZyjj0qHNG8OxrfMxvhbfUtYADe5jTlcda8FR2h5CDg/U6x18d0KdUqdGCslVjfdn0OduAC5l+DlhKlUNrts9NoNHQc1Sp4CzjtsbrINME6l3inq+ca7uow5jet8ov5NkurSrPljGAqIOTsMX4sTpQc2GwthZEqhYbtgIPFyuX4lANKYqQCTdxF/rGug6fdhr7CeN//XqeZ6e9s5b86lre2iG25O1J4NyUlfzcSmlUezla8NZ2tV7GHCiTqWUf+18XyT/jfARoZEQB81yu2ib11eoMlYhOUb48D6V+jTp07aGrvHdyFch3nVcJUdW7YexeAvKRqdiyCa2kIIRO6YvHAPKaorG5GU2GF91ed3l9+qEsyAsk6I6HggqRyhwLw7vVTvsNwJjChqGTlCW1FMa7dT3yM4I8VjPcm8IIJ8e6hwzScwULV0cxiYdTBBaXVVSbZxPXAag/WcY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,18 @@ after_success:
 before_deploy:
 - chmod +x bin/htmltest-$TRAVIS_OS_NAME
 
+env:
+  global:
+  - secure: "H3SLwfn+szCdi2CmAsfbpHLYJBd0gvMR7Ik9oiJm+haY8+Y+BRDCFcb5CX6yiKsfJpQDM8sLLsF6t7nmiZVPAHx5q0ORExe5ddS6HhjvACeH7DnYCoHpDZaVr8DP6TPOZcHE2JWX2gdxI4Rg10bsnvxVbCYzoCjFFUD6ZXlPTJvkPQFQgCjLg0xfDxZloIpkYtkmheIjvBzkPXLygZzhNNq7BzhvY3CyYn4Gpda09woOSmar1ccVaVurzszlxD4fEIdKPapcS8MPXS2a7LPA8A0glr04aX75F3SHZQ/KtOU5jrNPxfyto+btTsAzoNytUFynPKXTLhkGgVnmLuixlTCVaB5KkMlKUE5MILwl4rDmzcs7jfXA/NIXl28oBw8+LHoFLEF27V+fSoRa8yulOCg4v2yvATZvtyK96QZ8bpT8hVvccVJDWDZZeEzQQlCfsB/ENjAeb7ryQjluZfivZMT3b6GpBmDTJxfeiBqRp+YYZiaB1XPTr87IQ68AIzhr6E+EPvENV4R5oFCUgaFtC5ptq86WSfHb2Iwy21sGf7tFho/jprjVsy6qtJ6qtizwOHT4IEahIAOk4Itj/7oLi2nL+qSj4ST/LFFdzQljTA7fy3ADB6xrDgE5Sr1prYd+uEuLmf1ZTHtiKBsvflJdbzPTwWU+qFO5wT1aWxo46+c="
+
 deploy:
-  - provider: releases
-    api_key:
-      secure: ZV+Mttq0eaYALR9M/AQBnu9i0ytpT8bcWVvEwNjztRbLzsgGQOzReJiRI8gNUcrufRLI7G4n0feg9mCOLCD3kzG/7vYFiww2NzGk5zxLh8XSGDnTvd2Elm9DlCBmJTTgsS+HHxTo/0D4W5YeYo2UqWe8/5yvZHMdmKzqTRNwobccpkl9lCmUJXfX2tJ1fRlG6WKhTl7qhVVV/uj4m0pTOuVL3UmYiI5N5zFb/szAhGpmO0OHtlmRYqoaAcuBdml/dvfa4bcezuN63JIgb54DAMARjIGavJ8ehUeJKnsTXwNcEE/6AhTA9oMlEwNvy4FxZ28WpbzGupPOto6oW0apFdkeVaJ2eqzSd5kA6ql//Sc1EOQGyJmdDuHJ65/2JF5QnPaOzfid5PzUslrlC3Agby6Sikp0sLcfVamLe9P8PClvbm3qPI6UJf+B+miY0wYNhLnZUdBAuNTPwrorWt4RCTVyDAgdnFir6WSUsS7e5T+wgLh7YQ/YFRqORI719hGbNGfKurZEjCNchEbjVd0PhO3CUtWsh6P9Tn5HnJMcofWyqoxvOkSpeDVPYpwC+A095wqugp2T94kPAJUy05eR2q6va0jDtrwwmPcvGVnoH3kG8Hihxn0dANEIwighle/xOwle+xWr/x+8+tGedwhGeLal/sSCsUDYQi+Rpdk7AeY=
-    file: bin/htmltest-$TRAVIS_OS_NAME
+  - provider: script
     skip_cleanup: true
+    script: curl -sL http://git.io/goreleaser | bash
     on:
       tags: true
       repo: wjdp/htmltest
+      condition: $TRAVIS_OS_NAME = linux
   - provider: s3
     access_key_id: AKIAIH2ZE2KZBNCVEGCA
     secret_access_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - go test -v -race ./... # Run test suite
   - cmd: for /f %%i in ('"call powershell (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd-hh:mm:ssZ')"') do set BUILD_DATE=%%i
   - cmd: for /f %%i in ('"call git describe --tags"') do set VERSION=%%i
-  - cmd: go build -ldflags "-X main.buildDate=%BUILD_DATE% -X main.version=%VERSION%" -o bin/htmltest-%OS_NAME%.exe -x main.go
+  - cmd: go build -ldflags "-X main.date=%BUILD_DATE% -X main.version=%VERSION%" -o bin/htmltest-%OS_NAME%.exe -x main.go
   - cmd: .\bin\htmltest-%OS_NAME%.exe -h  # Print usage
   - cmd: .\bin\htmltest-%OS_NAME%.exe -v  # Print version
   - cmd: .\bin\htmltest-%OS_NAME%.exe -c htmldoc/fixtures/conf.yaml -l0 # Run config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,11 +28,3 @@ build_script:
 artifacts:
   - path: bin\*.exe
     name: htmltest-binaries
-
-deploy:
-  provider: GitHub
-  auth_token:
-      secure: 9+xdNIvrnAVRoTFYPvdfYxnSUtWXObdc4DUIndJwiliSsD44stBnDwCvPZ+3OH3e # your encrypted token from GitHub
-  artifact: htmltest-binaries
-  on:
-    appveyor_repo_tag: true        # deploy on tag push only

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 # Script for devs to build a copy of the app with build flags set
 
-go build -ldflags "-X main.buildDate=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/htmltest -x main.go
+go build -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/htmltest -x main.go

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ const cmdSeparator string = "===================================================
 
 var (
 	version   string
-	buildDate string
+	date string
 	fileMode  bool
 )
 
@@ -43,7 +43,7 @@ Options:
                                time considerably.
   -v, --version                Show version and build time.
 `
-	versionText := "htmltest " + version + "\n" + buildDate
+	versionText := "htmltest " + version + "\n" + date
 	arguments, _ := docopt.Parse(usage, nil, true, versionText, false)
 
 	// fmt.Println(arguments)


### PR DESCRIPTION
Implements the goreleaser part of #80 

- Remove use of travis GH releases deployment method
- Add goreleaser config
- Add goreleaser as a travis deploy script
- Swap `buildDate` ldflag with just `date` to align with goreleaser defaults.