### PR TITLE
Make IgnoreTagAttribute ignore both the entire element and all its children

### DIFF
--- a/htmldoc/document.go
+++ b/htmldoc/document.go
@@ -11,15 +11,16 @@ import (
 
 // Document struct, representation of a document within the tested site
 type Document struct {
-	FilePath        string                // Relative to the shell session
-	SitePath        string                // Relative to the site root
-	BasePath        string                // Base for relative links
-	htmlMutex       *sync.Mutex           // Controls access to htmlNode
-	htmlNode        *html.Node            // Parsed output
-	hashMap         map[string]*html.Node // Map of valid id/names of nodes
-	NodesOfInterest []*html.Node          // Slice of nodes to run checks on
-	State           DocumentState         // Link to a DocumentState struct
-	DoctypeNode     *html.Node            // Pointer to doctype node if exists
+	FilePath           string                // Relative to the shell session
+	SitePath           string                // Relative to the site root
+	BasePath           string                // Base for relative links
+	htmlMutex          *sync.Mutex           // Controls access to htmlNode
+	htmlNode           *html.Node            // Parsed output
+	hashMap            map[string]*html.Node // Map of valid id/names of nodes
+	NodesOfInterest    []*html.Node          // Slice of nodes to run checks on
+	State              DocumentState         // Link to a DocumentState struct
+	DoctypeNode        *html.Node            // Pointer to doctype node if exists
+	ignoreTagAttribute string                // Attribute to ignore element and children if found on element
 }
 
 // DocumentState struct, used by checks that depend on the document being
@@ -66,6 +67,11 @@ func (doc *Document) Parse() {
 // Internal recursive function that delves into the node tree and captures
 // nodes of interest and node id/names.
 func (doc *Document) parseNode(n *html.Node) {
+	// Ignore this tree if data-proofer-ignore set
+	if doc.ignoreTagAttribute != "" && AttrPresent(n.Attr, doc.ignoreTagAttribute) {
+		return
+	}
+
 	switch n.Type {
 	case html.DoctypeNode:
 		doc.DoctypeNode = n

--- a/htmldoc/document_store.go
+++ b/htmldoc/document_store.go
@@ -12,12 +12,13 @@ import (
 
 // DocumentStore struct, store of Documents including Document discovery
 type DocumentStore struct {
-	BasePath          string               // Path, relative to cwd, the site is located in
-	IgnorePatterns    []interface{}        // Regexes of directories to ignore
-	Documents         []*Document          // All of the documents, used to iterate over
-	DocumentPathMap   map[string]*Document // Maps slash separated paths to documents
-	DocumentExtension string               // File extension to look for
-	DirectoryIndex    string               // What file is the index of the directory
+	BasePath           string               // Path, relative to cwd, the site is located in
+	IgnorePatterns     []interface{}        // Regexes of directories to ignore
+	Documents          []*Document          // All of the documents, used to iterate over
+	DocumentPathMap    map[string]*Document // Maps slash separated paths to documents
+	DocumentExtension  string               // File extension to look for
+	DirectoryIndex     string               // What file is the index of the directory
+	IgnoreTagAttribute string               // Attribute to ignore element and children if found on element
 }
 
 // NewDocumentStore : Create and return a new Document store.
@@ -33,6 +34,8 @@ func (dS *DocumentStore) AddDocument(doc *Document) {
 	// Save reference to document to various data stores
 	dS.Documents = append(dS.Documents, doc)
 	dS.DocumentPathMap[doc.SitePath] = doc
+	// Pass some vars on
+	doc.ignoreTagAttribute = dS.IgnoreTagAttribute
 }
 
 // Discover : Discover all documents within DocumentStore.BasePath.

--- a/htmltest/check-generic.go
+++ b/htmltest/check-generic.go
@@ -15,11 +15,6 @@ func (hT *HTMLTest) checkGeneric(document *htmldoc.Document, node *html.Node, ke
 		return
 	}
 
-	// Ignore if data-proofer-ignore set
-	if htmldoc.AttrPresent(node.Attr, hT.opts.IgnoreTagAttribute) {
-		return
-	}
-
 	urlStr := htmldoc.GetAttr(node.Attr, key)
 	ref := htmldoc.NewReference(document, node, urlStr)
 

--- a/htmltest/check-img.go
+++ b/htmltest/check-img.go
@@ -9,12 +9,7 @@ import (
 
 func (hT *HTMLTest) checkImg(document *htmldoc.Document, node *html.Node) {
 	attrs := htmldoc.ExtractAttrs(node.Attr,
-		[]string{"src", "alt", "usemap", hT.opts.IgnoreTagAttribute})
-
-	// Ignore if data-proofer-ignore set
-	if htmldoc.AttrPresent(node.Attr, hT.opts.IgnoreTagAttribute) {
-		return
-	}
+		[]string{"src", "alt", "usemap"})
 
 	// Create reference
 	ref := htmldoc.NewReference(document, node, attrs["src"])

--- a/htmltest/check-img_test.go
+++ b/htmltest/check-img_test.go
@@ -96,6 +96,12 @@ func TestImageIgnorable(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
+func TestImageIgnorableChildren(t *testing.T) {
+	// ignores images contained within a parent element with data-proofer-ignore
+	hT := tTestFile("fixtures/images/ignorableImagesChildren.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestImageSrcMising(t *testing.T) {
 	// fails for image with no src
 	hT := tTestFile("fixtures/images/missingImageSrc.html")

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -14,12 +14,7 @@ import (
 
 func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 	attrs := htmldoc.ExtractAttrs(node.Attr,
-		[]string{"href", "rel", hT.opts.IgnoreTagAttribute})
-
-	// Ignore if data-proofer-ignore set
-	if htmldoc.AttrPresent(node.Attr, hT.opts.IgnoreTagAttribute) {
-		return
-	}
+		[]string{"href", "rel"})
 
 	// Check if favicon
 	if htmldoc.AttrPresent(node.Attr, "rel") &&

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -20,6 +20,13 @@ func TestAnchorIgnorable(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
+func TestAnchorIgnorableChildren(t *testing.T) {
+	// ignores links marked as ignore data-proofer-ignore in child elements
+	hT := tTestFile("fixtures/links/ignorableLinksChildren.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
+
 func TestAnchorMatchIgnore(t *testing.T) {
 	// ignores links in IgnoreURLs
 	hT := tTestFileOpts("fixtures/links/brokenLinkExternalSingle.html",

--- a/htmltest/check-meta.go
+++ b/htmltest/check-meta.go
@@ -15,7 +15,7 @@ func (hT *HTMLTest) checkMeta(document *htmldoc.Document, node *html.Node) {
 
 func (hT *HTMLTest) checkMetaRefresh(document *htmldoc.Document, node *html.Node) {
 	attrs := htmldoc.ExtractAttrs(node.Attr,
-		[]string{"http-equiv", "content", hT.opts.IgnoreTagAttribute})
+		[]string{"http-equiv", "content"})
 
 	// Checks for meta refresh redirect tag
 	if attrs["http-equiv"] == "refresh" {

--- a/htmltest/check-script.go
+++ b/htmltest/check-script.go
@@ -8,12 +8,7 @@ import (
 
 func (hT *HTMLTest) checkScript(document *htmldoc.Document, node *html.Node) {
 	attrs := htmldoc.ExtractAttrs(node.Attr,
-		[]string{"src", hT.opts.IgnoreTagAttribute})
-
-	// Ignore if data-proofer-ignore set
-	if htmldoc.AttrPresent(node.Attr, hT.opts.IgnoreTagAttribute) {
-		return
-	}
+		[]string{"src"})
 
 	// Create reference
 	ref := htmldoc.NewReference(document, node, attrs["src"])

--- a/htmltest/check-script_test.go
+++ b/htmltest/check-script_test.go
@@ -87,3 +87,8 @@ func TestScriptIgnorable(t *testing.T) {
 	hT := tTestFile("fixtures/scripts/scriptIgnorable.html")
 	tExpectIssueCount(t, hT, 0)
 }
+
+func TestScriptIgnorableChildren(t *testing.T) {
+	hT := tTestFile("fixtures/scripts/scriptIgnorableChildren.html")
+	tExpectIssueCount(t, hT, 0)
+}

--- a/htmltest/fixtures/images/ignorableImagesChildren.html
+++ b/htmltest/fixtures/images/ignorableImagesChildren.html
@@ -1,0 +1,20 @@
+<html>
+
+<body>
+
+<p data-proofer-ignore="true">Blah blah blah. <img alt="A broken image" src="http://www.whatthehell" /> </p>
+
+
+<footer>
+    <section data-proofer-ignore>
+        <div>
+            <span>
+                <img alt="A broken image" src="http://www.whatthehell" />
+            </span>
+        </div>
+    </section>
+</footer>
+
+</body>
+
+</html>

--- a/htmltest/fixtures/links/ignorableLinksChildren.html
+++ b/htmltest/fixtures/links/ignorableLinksChildren.html
@@ -1,0 +1,26 @@
+<html>
+
+<body>
+<div class="myDiv" data-proofer-ignore="true">
+    <a href="http://www.asdo3IRJ395295jsingrkrg4.com" data-proofer-ignore="true">broken link!</a>
+</div>
+
+<div data-proofer-ignore=true>
+    <span>
+        <a href="#anadaasdadsadschor">Anchor relative to nothing</a>
+    </span>
+</div>
+
+<section>
+    <article data-proofer-ignore>
+        <div>
+            <span>
+                <a href="../whaadadt.html">Relative to nothing</a>
+            </span>
+        </div>
+    </article>
+</section>
+
+</body>
+
+</html>

--- a/htmltest/fixtures/scripts/scriptIgnorableChildren.html
+++ b/htmltest/fixtures/scripts/scriptIgnorableChildren.html
@@ -1,0 +1,13 @@
+<html>
+<head data-proofer-ignore>
+  <script src="/assets/main.js"></script>
+<body>
+  <div>
+      <div data-proofer-ignore>
+          <div>
+              <script src="/assets/main.js" data-proofer-ignore></script>
+          </div>
+      </div>
+  </div>
+</body>
+</html>

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -124,6 +124,7 @@ func Test(optsUser map[string]interface{}) (*HTMLTest, error) {
 	hT.documentStore.DocumentExtension = hT.opts.FileExtension
 	hT.documentStore.DirectoryIndex = hT.opts.DirectoryIndex
 	hT.documentStore.IgnorePatterns = hT.opts.IgnoreDirs
+	hT.documentStore.IgnoreTagAttribute = hT.opts.IgnoreTagAttribute
 	// Discover documents
 	hT.documentStore.Discover()
 


### PR DESCRIPTION
The IgnoreTagAttribute used to only apply to the element it was applied to and was re-implemented on each check function.

Now we implement this check when we parse the document and completely ignore any element (and their children) where we find this attribute.

This PR implements #95 