### PR TITLE
Fix panic when meta refresh url starts with single or double quote

### DIFF
--- a/htmltest/check-meta.go
+++ b/htmltest/check-meta.go
@@ -28,6 +28,15 @@ func (hT *HTMLTest) checkMetaRefresh(document *htmldoc.Document, node *html.Node
 		// Define ref from this
 		var ref *htmldoc.Reference
 		if len(contentSplit) == 2 {
+			if contentSplit[1][0]==34 || contentSplit[1][0]==39 {
+				hT.issueStore.AddIssue(issues.Issue{
+					Level:     issues.LevelError,
+					Message:   "url in meta refresh must not start with single or double quote",
+					Reference: ref,
+				})
+				return
+			}
+
 			ref = htmldoc.NewReference(document, node, contentSplit[1])
 		} else {
 			ref = htmldoc.NewReference(document, node, "")

--- a/htmltest/check-meta_test.go
+++ b/htmltest/check-meta_test.go
@@ -83,3 +83,10 @@ func TestMetaRefreshContentInvalid(t *testing.T) {
 	tExpectIssueCount(t, hT3, 1)
 	tExpectIssue(t, hT3, "invalid content attribute in meta refresh", 1)
 }
+
+// Fails when meta refresh url starts with a single or double quote
+func TestIssue92(t *testing.T) {
+	hT := tTestFile("fixtures/meta/issues/92.html")
+	tExpectIssueCount(t, hT, 2)
+	tExpectIssue(t, hT, "url in meta refresh must not start with single or double quote", 2)
+}

--- a/htmltest/fixtures/meta/issues/92.html
+++ b/htmltest/fixtures/meta/issues/92.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>ox-hugo Test Site</title>
+    <meta http-equiv="refresh" content="0; URL='https://github.com/kaushalmodi/ox-hugo/issues'" />
+    <meta http-equiv="refresh" content='0; URL="https://github.com/kaushalmodi/ox-hugo/issues"' />
+</head>
+</html>


### PR DESCRIPTION
Will now raise an issue that meta url should not start with these characters as per spec

https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh

> For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:
>
> - just a valid non-negative integer, or
> - a valid non-negative integer, followed by a U+003B SEMICOLON character (;), followed by one or more ASCII whitespace, followed by a substring that is an ASCII case-insensitive match for the string "URL", followed by a U+003D EQUALS SIGN character (=), followed by a valid URL string that does not start with a literal U+0027 APOSTROPHE (') or U+0022 QUOTATION MARK (") character.

Fixes #92 