### PR TITLE
Ignore hrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `IgnoreURLs` | Array of regexs of URLs to ignore. | empty |
 | `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files. | empty |
 | `IgnoreInternalEmptyHash` | When true prevents raising an error for links with `href="#"`. | `false` |
+| `IgnoreBlankHref` | When true ignores links with `href=""`. | `false` |
 | `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |
 | `IgnoreAltMissing` | Turns off image alt attribute checking. | `false` |
 | `IgnoreDirectoryMissingTrailingSlash` | Turns off errors for links to directories without a trailing slash. | `false` |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `EnforceHTTPS` | Fails when encountering an `http://` link. Useful to prevent mixed content errors when serving over HTTPS. | `false` |
 | `IgnoreURLs` | Array of regexs of URLs to ignore. | empty |
 | `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files. | empty |
+| `IgnoreHrefs` | Array of exact match href values to not check. | empty |
 | `IgnoreInternalEmptyHash` | When true prevents raising an error for links with `href="#"`. | `false` |
 | `IgnoreBlankHref` | When true ignores links with `href=""`. | `false` |
 | `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 # Script for devs to build a copy of the app with build flags set
-export GOPATH=/home/packager/go
 
 go build -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/htmltest -x main.go

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 # Script for devs to build a copy of the app with build flags set
+export GOPATH=/home/packager/go
 
 go build -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/htmltest -x main.go

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -52,6 +52,16 @@ func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 		}
 	}
 
+	// Don't check if href is in ignored list
+	if hT.opts.isHrefIgnored(attrs["href"]) {
+		hT.issueStore.AddIssue(issues.Issue{
+			Level:     issues.LevelDebug,
+			Message:   "skipping href in IgnoreHrefs",
+			Reference: ref,
+		})
+		return;
+	}
+
 	// Blank href
 	if attrs["href"] == "" {
 		if !hT.opts.IgnoreBlankHref {

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -54,11 +54,13 @@ func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 
 	// Blank href
 	if attrs["href"] == "" {
-		hT.issueStore.AddIssue(issues.Issue{
-			Level:     issues.LevelError,
-			Message:   "href blank",
-			Reference: ref,
-		})
+		if !hT.opts.IgnoreBlankHref {
+			hT.issueStore.AddIssue(issues.Issue{
+				Level:     issues.LevelError,
+				Message:   "href blank",
+				Reference: ref,
+			})
+		}
 		return
 	}
 

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -39,6 +39,7 @@ type Options struct {
 
 	IgnoreURLs []interface{}
 	IgnoreDirs []interface{}
+	IgnoreHrefs[]interface{}
 
 	IgnoreInternalEmptyHash             bool
 	IgnoreBlankHref                     bool
@@ -101,6 +102,7 @@ func DefaultOptions() map[string]interface{} {
 
 		"IgnoreURLs": []interface{}{},
 		"IgnoreDirs": []interface{}{},
+		"IgnoreHrefs":[]interface{}{},
 
 		"IgnoreInternalEmptyHash":             false,
 		"IgnoreBlankHref":                     false,
@@ -172,6 +174,16 @@ func InList(list []string, key string) bool {
 func (opts *Options) isURLIgnored(url string) bool {
 	for _, item := range opts.IgnoreURLs {
 		if ok, _ := regexp.MatchString(item.(string), url); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Is the href in ignored list
+func (opts *Options) isHrefIgnored(href string) bool {
+	for _, item := range opts.IgnoreHrefs {
+		if (href == item.(string)) {
 			return true
 		}
 	}

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	IgnoreDirs []interface{}
 
 	IgnoreInternalEmptyHash             bool
+	IgnoreBlankHref                     bool
 	IgnoreCanonicalBrokenLinks          bool
 	IgnoreAltMissing                    bool
 	IgnoreDirectoryMissingTrailingSlash bool
@@ -102,6 +103,7 @@ func DefaultOptions() map[string]interface{} {
 		"IgnoreDirs": []interface{}{},
 
 		"IgnoreInternalEmptyHash":             false,
+		"IgnoreBlankHref":                     false,
 		"IgnoreCanonicalBrokenLinks":          true,
 		"IgnoreAltMissing":                    false,
 		"IgnoreDirectoryMissingTrailingSlash": false,


### PR DESCRIPTION
Allow to specify list of specifically ignored href values:
this is useful if user knows href is valid, but it cannot be verified (e.g. mod_rewrite is used
for specific URL and it cannot be checked in offline mode)