### PR TITLE
added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+ARG base=ubuntu:18.04
+FROM ${base}
+
+RUN apt-get update && apt-get install curl -y
+# Install htmltest into $PATH
+RUN curl https://htmltest.wjdp.uk | sudo bash -s -- -b /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
-ARG base=ubuntu:18.04
-FROM ${base}
+ARG GO_VERSION=1.11
+ARG TARGET=alpine:3.9
 
-RUN apt-get update && apt-get install curl -y
-# Install htmltest into $PATH
-RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
+FROM golang:${GO_VERSION}-alpine AS builder
 
-WORKDIR /test/
+RUN apk add --no-cache ca-certificates git
 
+WORKDIR /src
+COPY ./go.mod ./go.sum ./
+RUN go mod download
+
+# Import the code from the context.
+COPY ./ ./
+RUN CGO_ENABLED=0 go build -installsuffix 'static' -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o /app .
+
+FROM ${TARGET} AS final
+
+WORKDIR /bin
+COPY --from=builder /app ./htmltest
+WORKDIR /test
 CMD [ "htmltest", "./"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN apt-get update && apt-get install curl -y
 RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
 
 WORKDIR /test/
+
 CMD [ "htmltest", "./"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ FROM ${base}
 
 RUN apt-get update && apt-get install curl -y
 # Install htmltest into $PATH
-RUN curl https://htmltest.wjdp.uk | sudo bash -s -- -b /usr/local/bin
+RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
+
+CMD [ "htmltest", "./"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN apt-get update && apt-get install curl -y
 # Install htmltest into $PATH
 RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
 
+WORKDIR /test/
 CMD [ "htmltest", "./"]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ By default this will install `htmltest` into `./bin` of your current directory, 
 Mount your directory with html files into the container and test them.
 
 If you need more arguments to the test run it like this:  
-```docker run v $(pwd):/test --rm wjdp/htmltest htmltest -l 3 -s```
+```docker run -v $(pwd):/test --rm wjdp/htmltest htmltest -l 3 -s```
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ By default this will install `htmltest` into `./bin` of your current directory, 
 
 :arrow_down: Download the [latest binary release](https://github.com/wjdp/htmltest/releases/latest) and put it somewhere on your PATH.
 
+### Docker
+
+```docker run -v $(pwd):/test --rm wjdp/htmltest```  
+Mount your directory with html files into the container and test them.
+
+If you need more arguments to the test run it like this:  
+```docker run v $(pwd):/test --rm wjdp/htmltest htmltest -l 3 -s```
+
 ### Notes
 
 We store temporary files in `tmp/.htmltest` by default. You probably want to ignore that in your version control system, and perhaps [cache it in your CI system](https://docs.travis-ci.com/user/caching/#Arbitrary-directories).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ By default this will install `htmltest` into `./bin` of your current directory, 
 
 :arrow_down: Download the [latest binary release](https://github.com/wjdp/htmltest/releases/latest) and put it somewhere on your PATH.
 
-### Docker
+### :whale: Docker
 
 ```docker run -v $(pwd):/test --rm wjdp/htmltest```  
 Mount your directory with html files into the container and test them.


### PR DESCRIPTION
**WHY**:  
To use it as a proper and flexible CI Tool.

**How To Use**:  
Basic manual usage would be something like this:  ```docker run -v $(pwd):/test --rm wjdp/htmltest```  

In my gitlab-ci.yml it would look like:
```yaml
test:
  stage: test
  image: wjdp/htmltest
  allow_failure: true
  script:
    - htmltest -c ci/htmltest.yml
```

It would be great if you connect this project to the dockerhub so a current/latest image will be build.