### PR TITLE
Fix for IgnoreAltBlank when alt=""

### DIFF
--- a/htmltest/check-img.go
+++ b/htmltest/check-img.go
@@ -21,7 +21,7 @@ func (hT *HTMLTest) checkImg(document *htmldoc.Document, node *html.Node) {
 			Message:   "alt attribute missing",
 			Reference: ref,
 		})
-	} else if htmldoc.AttrPresent(node.Attr, "alt") {
+	} else if htmldoc.AttrPresent(node.Attr, "alt") && !hT.opts.IgnoreAltMissing {
 		// Following checks require alt attr is present
 		if len(attrs["alt"]) == 0 {
 			// Check alt has length, fail if empty

--- a/htmltest/check-img_test.go
+++ b/htmltest/check-img_test.go
@@ -193,6 +193,13 @@ func TestImageAltIgnoreMissing(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
+func TestImageAltIgnoreMissingWithBlank(t *testing.T) {
+	// ignores missing alt tags when asked
+	hT := tTestFileOpts("fixtures/images/altBlank.html",
+		map[string]interface{}{"IgnoreAltMissing": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestImagePre(t *testing.T) {
 	// works for broken images within pre & code
 	hT := tTestFile("fixtures/images/badImagesInPre.html")

--- a/htmltest/fixtures/images/altBlank.html
+++ b/htmltest/fixtures/images/altBlank.html
@@ -1,0 +1,10 @@
+<html>
+
+<body>
+
+
+<img src="gpl.png" alt=""/>Relative to self
+
+</body>
+
+</html>


### PR DESCRIPTION
Previously would only ignore alts if missing, now does what it says it does and disables all alt checks.

Fixes #115 