### PR TITLE
Add IgnoreEmptyHref option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `IgnoreURLs` | Array of regexs of URLs to ignore. | empty |
 | `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files. | empty |
 | `IgnoreInternalEmptyHash` | When true prevents raising an error for links with `href="#"`. | `false` |
+| `IgnoreEmptyHref` | When true prevents raising an error for links with `href=""`. | `false` |
 | `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |
 | `IgnoreAltMissing` | Turns off image alt attribute checking. | `false` |
 | `IgnoreDirectoryMissingTrailingSlash` | Turns off errors for links to directories without a trailing slash. | `false` |

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -54,11 +54,13 @@ func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 
 	// Blank href
 	if attrs["href"] == "" {
-		hT.issueStore.AddIssue(issues.Issue{
-			Level:     issues.LevelError,
-			Message:   "href blank",
-			Reference: ref,
-		})
+		if !hT.opts.IgnoreEmptyHref {
+			hT.issueStore.AddIssue(issues.Issue{
+				Level:     issues.LevelError,
+				Message:   "href blank",
+				Reference: ref,
+			})
+		}
 		return
 	}
 

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -467,6 +467,13 @@ func TestLinkHrefBlank(t *testing.T) {
 	tExpectIssue(t, hT, "href blank", 1)
 }
 
+func TestLinkHrefBlankIgnore(t *testing.T) {
+	// works for empty href within link elements when ignoring
+	hT := tTestFileOpts("fixtures/links/head_link_href_empty.html",
+		map[string]interface{}{"IgnoreEmptyHref": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestLinkHrefAbsent(t *testing.T) {
 	// fails for absent href within link elements
 	hT := tTestFile("fixtures/links/head_link_href_absent.html")

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	IgnoreDirs []interface{}
 
 	IgnoreInternalEmptyHash             bool
+	IgnoreEmptyHref                     bool
 	IgnoreCanonicalBrokenLinks          bool
 	IgnoreAltMissing                    bool
 	IgnoreDirectoryMissingTrailingSlash bool
@@ -103,6 +104,7 @@ func DefaultOptions() map[string]interface{} {
 		"IgnoreDirs": []interface{}{},
 
 		"IgnoreInternalEmptyHash":             false,
+		"IgnoreEmptyHref":                     false,
 		"IgnoreCanonicalBrokenLinks":          true,
 		"IgnoreAltMissing":                    false,
 		"IgnoreDirectoryMissingTrailingSlash": false,


### PR DESCRIPTION
Thanks for the useful project! I have started trying to use it with Hugo. However, my site uses Hugo templates and being unable to disable the empty href check makes it a non-starter. 

Please review this simple PR for adding an option for that.
