### PR TITLE
Add ca-certificates to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN CGO_ENABLED=0 go build -installsuffix 'static' -ldflags "-X main.date=`date 
 
 FROM ${TARGET} AS final
 
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+
 WORKDIR /bin
 COPY --from=builder /app ./htmltest
 WORKDIR /test


### PR DESCRIPTION
Running htmltest from Docker image fails if the site has HTTPS URLs
because the Docker image does not contain common CA certificates.