### PR TITLE
Add the ability for html test to accept servers using AIA.

### DIFF
--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -108,7 +108,7 @@ func TestAnchorExternalInsecureOptionIgnored(t *testing.T) {
 	hT := tTestFileOpts("fixtures/links/issues/94.html",
 		map[string]interface{}{
 			"EnforceHTTPS": true,
-			"IgnoreURLs": []interface{}{"plantuml.com", "plantuml.net", "forum.plantuml.net"},
+			"IgnoreURLs":   []interface{}{"plantuml.com", "plantuml.net", "forum.plantuml.net"},
 		})
 	tExpectIssueCount(t, hT, 0)
 }
@@ -156,6 +156,14 @@ func TestAnchorExternalHTTPSInvalid(t *testing.T) {
 	hT := tTestFileOpts("fixtures/links/https-invalid.html",
 		map[string]interface{}{"VCREnable": true})
 	tExpectIssueCount(t, hT, 6)
+}
+
+func TestAnchorExternalHTTPSMissingChain(t *testing.T) {
+	// should support https aia
+	// see issue #130
+	hT := tTestFileOpts("fixtures/links/https-incomplete-chain.html",
+		map[string]interface{}{"VCREnable": true})
+	tExpectIssue(t, hT, "incomplete certificate chain", 1)
 }
 
 func TestAnchorExternalHTTPSBadH2(t *testing.T) {

--- a/htmltest/fixtures/links/https-incomplete-chain.html
+++ b/htmltest/fixtures/links/https-incomplete-chain.html
@@ -1,0 +1,12 @@
+<html>
+
+<body>
+
+	<p>Blah blah blah. <a href="https://github.com/octocat/Spoon-Knife/issues">An HTTPS link!</a></p>
+
+  <p>
+    <a href="https://incomplete-chain.badssl.com/">incomplete-chain</a>
+  </p>
+</body>
+
+</html>

--- a/htmltest/util.go
+++ b/htmltest/util.go
@@ -1,7 +1,78 @@
 package htmltest
 
-import "net/http"
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type CertChainErr struct {
+	cert    *x509.Certificate
+	chain   *x509.CertPool
+	hintErr error
+}
+
+func (e CertChainErr) Error() string {
+	s := "x509: could not validate certificate chain"
+	if e.hintErr != nil {
+		s += fmt.Sprintf(" (possibly because of %q)", e.hintErr)
+	}
+	return s
+}
 
 func statusCodeValid(code int) bool {
 	return code == http.StatusPartialContent || code == http.StatusOK
+}
+
+func validateCertChain(cert *x509.Certificate) (err error) {
+	if cert.IssuingCertificateURL == nil {
+		return CertChainErr{cert: cert}
+	}
+
+	intermediates := x509.NewCertPool()
+	//roots, err := x509.SystemCertPool()
+	if err != nil {
+		return CertChainErr{cert: cert}
+	}
+	var certsToFetch []string = cert.IssuingCertificateURL
+
+	for i := 0; i < len(certsToFetch); i++ {
+		url := certsToFetch[i]
+
+		resp, err := http.Get(url)
+		if err != nil {
+			return CertChainErr{cert: cert, chain: intermediates, hintErr: err}
+		}
+
+		if resp.StatusCode != 200 {
+			return CertChainErr{cert: cert, chain: intermediates, hintErr: fmt.Errorf("could not fetch certificate at %s (status %d)", url, resp.StatusCode)}
+		}
+
+		certBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return CertChainErr{cert: cert, chain: intermediates, hintErr: err}
+		}
+
+		newCert, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			return CertChainErr{cert: cert, chain: intermediates, hintErr: err}
+		}
+
+		if newCert.CheckSignatureFrom(cert) == nil {
+			// we have out root
+			break
+		}
+
+		intermediates.AddCert(newCert)
+
+		if newCert.IssuingCertificateURL != nil {
+			certsToFetch = append(certsToFetch, newCert.IssuingCertificateURL...)
+		}
+	}
+
+	_, err = cert.Verify(x509.VerifyOptions{
+		Intermediates: intermediates,
+	})
+	return
 }


### PR DESCRIPTION
Generate an error instead of a warning as these are likely due to issues with a remote server out of your control and will work in most browsers.

Closes #130 