### PR TITLE
Disable VCR for TestAnchorExternalHTTPSMissingChain

### DIFF
--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -162,7 +162,7 @@ func TestAnchorExternalHTTPSMissingChain(t *testing.T) {
 	// should support https aia
 	// see issue #130
 	hT := tTestFileOpts("fixtures/links/https-incomplete-chain.html",
-		map[string]interface{}{"VCREnable": true})
+		map[string]interface{}{"VCREnable": false})
 	tExpectIssue(t, hT, "incomplete certificate chain", 1)
 }
 


### PR DESCRIPTION
VCR doesn't seem to encode enough for this test to pass with the mocked result.