### PR TITLE
Add option: `IgnoreExternalBrokenLinks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `IgnoreInternalEmptyHash` | When true prevents raising an error for links with `href="#"`. | `false` |
 | `IgnoreEmptyHref` | When true prevents raising an error for links with `href=""`. | `false` |
 | `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |
+| `IgnoreExternalBrokenLinks` | When true produces a warning, rather than an error, for broken external links. Useful when testing a site having hundreds of external links. | `false` |
 | `IgnoreAltMissing` | Turns off image alt attribute checking. | `false` |
 | `IgnoreDirectoryMissingTrailingSlash` | Turns off errors for links to directories without a trailing slash. | `false` |
 | `IgnoreSSLVerify` | Turns off x509 errors for self-signed certificates. | `false` |

--- a/htmltest/check-generic.go
+++ b/htmltest/check-generic.go
@@ -57,10 +57,14 @@ func (hT *HTMLTest) enforceHTTPS(ref *htmldoc.Reference) {
 	if hT.opts.isURLIgnored(ref.URLString()) {
 		return
 	}
+	issueLevel := issues.LevelError
+	if hT.opts.IgnoreExternalBrokenLinks {
+		issueLevel = issues.LevelWarning
+	}
 
 	if hT.opts.EnforceHTTPS {
 		hT.issueStore.AddIssue(issues.Issue{
-			Level:     issues.LevelError,
+			Level:     issueLevel,
 			Message:   "is not an HTTPS target",
 			Reference: ref,
 		})

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -111,6 +111,10 @@ func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 }
 
 func (hT *HTMLTest) checkExternal(ref *htmldoc.Reference) {
+	issueLevel := issues.LevelError
+	if hT.opts.IgnoreExternalBrokenLinks {
+		issueLevel = issues.LevelWarning
+	}
 	if !hT.opts.CheckExternal {
 		hT.issueStore.AddIssue(issues.Issue{
 			Level:     issues.LevelDebug,
@@ -184,7 +188,7 @@ func (hT *HTMLTest) checkExternal(ref *htmldoc.Reference) {
 				cleanedMessage := strings.TrimPrefix(err.Error(), prefix)
 				// Add error
 				hT.issueStore.AddIssue(issues.Issue{
-					Level:     issues.LevelError,
+					Level:     issueLevel,
 					Message:   cleanedMessage,
 					Reference: ref,
 				})
@@ -192,7 +196,7 @@ func (hT *HTMLTest) checkExternal(ref *htmldoc.Reference) {
 			}
 			if strings.Contains(err.Error(), "Client.Timeout") {
 				hT.issueStore.AddIssue(issues.Issue{
-					Level:     issues.LevelError,
+					Level:     issueLevel,
 					Message:   "request exceeded our ExternalTimeout",
 					Reference: ref,
 				})
@@ -213,7 +217,7 @@ func (hT *HTMLTest) checkExternal(ref *htmldoc.Reference) {
 
 			// Unhandled client error, return generic error
 			hT.issueStore.AddIssue(issues.Issue{
-				Level:     issues.LevelError,
+				Level:     issueLevel,
 				Message:   err.Error(),
 				Reference: ref,
 			})
@@ -249,7 +253,7 @@ func (hT *HTMLTest) checkExternal(ref *htmldoc.Reference) {
 		} else {
 			// Failed VCRed requests end up here with a status code of zero
 			hT.issueStore.AddIssue(issues.Issue{
-				Level:     issues.LevelError,
+				Level:     issueLevel,
 				Message:   fmt.Sprintf("%s %d", "Non-OK status:", statusCode),
 				Reference: ref,
 			})

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -42,12 +42,27 @@ func TestAnchorExternalBroken(t *testing.T) {
 	tExpectIssueCount(t, hT, 1)
 }
 
+func TestAnchorExternalBrokenOption(t *testing.T) {
+	// passes for broken external links when asked
+	hT := tTestFileOpts("fixtures/links/brokenLinkExternal.html",
+		map[string]interface{}{"IgnoreExternalBrokenLinks": true, "VCREnable": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorExternalBrokenNoVCR(t *testing.T) {
 	// fails for broken external links without VCR. This is needed as the code that handles 'dial tcp' errors doesn't
 	// get called with VCR. It returns a rather empty response with status code of 0.
 	tSkipShortExternal(t)
 	hT := tTestFile("fixtures/links/brokenLinkExternal.html")
 	tExpectIssueCount(t, hT, 1)
+}
+
+func TestAnchorExternalBrokenOptionNoVCR(t *testing.T) {
+	// passes for broken external links without VCR when asked.
+	tSkipShortExternal(t)
+	hT := tTestFileOpts("fixtures/links/brokenLinkExternal.html",
+		map[string]interface{}{"IgnoreExternalBrokenLinks": true})
+	tExpectIssueCount(t, hT, 0)
 }
 
 func TestAnchorExternalIgnore(t *testing.T) {
@@ -103,6 +118,13 @@ func TestAnchorExternalInsecureOption(t *testing.T) {
 	tExpectIssue(t, hT, "is not an HTTPS target", 1)
 }
 
+func TestAnchorExternalBrokenOptionInsecure(t *testing.T) {
+	// passes for non-HTTPS links when asked
+	hT := tTestFileOpts("fixtures/links/non_https.html",
+		map[string]interface{}{"EnforceHTTPS": true, "IgnoreExternalBrokenLinks": true, "VCREnable": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorExternalInsecureOptionIgnored(t *testing.T) {
 	// passes when checking for non-HTTPS links but they're in the IgnoreURLs list
 	hT := tTestFileOpts("fixtures/links/issues/94.html",
@@ -120,12 +142,26 @@ func TestAnchorExternalHrefIP(t *testing.T) {
 	tExpectIssueCount(t, hT, 2)
 }
 
+func TestAnchorExternalBrokenOptionHrefIP(t *testing.T) {
+	// passes for broken IP address links when asked
+	hT := tTestFileOpts("fixtures/links/ip_href.html",
+		map[string]interface{}{"VCREnable": true, "IgnoreExternalBrokenLinks": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorExternalHrefIPTimeout(t *testing.T) {
 	// fails for broken IP address links
 	hT := tTestFileOpts("fixtures/links/ip_timeout.html",
 		map[string]interface{}{"ExternalTimeout": 1})
 	tExpectIssueCount(t, hT, 1)
 	tExpectIssue(t, hT, "request exceeded our ExternalTimeout", 1)
+}
+
+func TestAnchorExternalBrokenOptionHrefIPTimeout(t *testing.T) {
+	// passes for broken IP address links when aksed
+	hT := tTestFileOpts("fixtures/links/ip_timeout.html",
+		map[string]interface{}{"IgnoreExternalBrokenLinks": true, "ExternalTimeout": 1})
+	tExpectIssueCount(t, hT, 0)
 }
 
 func TestAnchorExternalFollowRedirects(t *testing.T) {
@@ -158,12 +194,26 @@ func TestAnchorExternalHTTPSInvalid(t *testing.T) {
 	tExpectIssueCount(t, hT, 6)
 }
 
+func TestAnchorExternalBrokenOptionHTTPSInvalid(t *testing.T) {
+	// should pass for invalid https when asked
+	hT := tTestFileOpts("fixtures/links/https-invalid.html",
+		map[string]interface{}{"IgnoreExternalBrokenLinks": true, "VCREnable": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorExternalHTTPSMissingChain(t *testing.T) {
 	// should support https aia
 	// see issue #130
 	hT := tTestFileOpts("fixtures/links/https-incomplete-chain.html",
 		map[string]interface{}{"VCREnable": false})
 	tExpectIssue(t, hT, "incomplete certificate chain", 1)
+}
+
+func TestAnchorExternalBrokenOptionHTTPSMissingChain(t *testing.T) {
+	// should pass for incomplete chains when asked
+	hT := tTestFileOpts("fixtures/links/https-incomplete-chain.html",
+		map[string]interface{}{"IgnoreExternalBrokenLinks": true, "VCREnable": false})
+	tExpectIssueCount(t, hT, 0)
 }
 
 func TestAnchorExternalHTTPSBadH2(t *testing.T) {
@@ -195,6 +245,13 @@ func TestAnchorExternalMissingProtocolInvalid(t *testing.T) {
 		map[string]interface{}{"VCREnable": true})
 	tExpectIssueCount(t, hT, 1)
 	// tExpectIssue(t, hT, "no such host", 1)
+}
+
+func TestAnchorExternalBrokenOptionMissingProtocol(t *testing.T) {
+	// passes for invalid links missing the protocol when asked
+	hT := tTestFileOpts("fixtures/links/link_missing_protocol_invalid.html",
+		map[string]interface{}{"IgnoreExternalBrokenLinks": true, "VCREnable": true})
+	tExpectIssueCount(t, hT, 0)
 }
 
 func TestLinkExternalHrefPipes(t *testing.T) {

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -43,6 +43,7 @@ type Options struct {
 	IgnoreInternalEmptyHash             bool
 	IgnoreEmptyHref                     bool
 	IgnoreCanonicalBrokenLinks          bool
+	IgnoreExternalBrokenLinks           bool
 	IgnoreAltMissing                    bool
 	IgnoreDirectoryMissingTrailingSlash bool
 	IgnoreSSLVerify                     bool
@@ -106,6 +107,7 @@ func DefaultOptions() map[string]interface{} {
 		"IgnoreInternalEmptyHash":             false,
 		"IgnoreEmptyHref":                     false,
 		"IgnoreCanonicalBrokenLinks":          true,
+		"IgnoreExternalBrokenLinks":           false,
 		"IgnoreAltMissing":                    false,
 		"IgnoreDirectoryMissingTrailingSlash": false,
 		"IgnoreSSLVerify":                     false,


### PR DESCRIPTION
Do let me know if it is useful, we particularly required this while checking links for [julialang.org](https://julialang.org) site which has a large number of links.

I'll add tests and docs soon, if this idea looks good enough.

Closes https://github.com/wjdp/htmltest/issues/139

cc @wjdp 