### PR TITLE
Support for installing on OpenBSD

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
       - windows
       - darwin
       - linux
+      - openbsd
     goarch:
       - 386
       - amd64
@@ -30,6 +31,7 @@ archive:
     windows: windows
     386: i386
     amd64: amd64
+    openbsd: openbsd
   format_overrides:
     - goos: windows
       format: zip

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ By default this will install `htmltest` into `./bin` of your current directory, 
 
 :arrow_down: Download the [latest binary release](https://github.com/wjdp/htmltest/releases/latest) and put it somewhere on your PATH.
 
+### :blowfish: OpenBSD
+
+:arrow_down: Download the [latest binary release](https://github.com/wjdp/htmltest/releases/latest) and put it somewhere on your PATH.
+
+You can also build from sources by cloning this repo and running `sh build.sh`, which puts the `htmltest` executable in the `./bin` dir. Use in place, or install to path such as `/usr/local/bin`.
+
+
 ### :whale: Docker
 
 ```docker run -v $(pwd):/test --rm wjdp/htmltest```  


### PR DESCRIPTION
re https://github.com/wjdp/htmltest/issues/141

 - builds binaries for OpenBSD during release
 - adds notes on installation in README

![openbsd_install_notes](https://user-images.githubusercontent.com/2066833/72211446-522a6a80-34c3-11ea-93bc-9167f1e2dccf.png)


