### PR TITLE
Using ENTRYPOINT to simplify docker run semantics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 WORKDIR /bin
 COPY --from=builder /app ./htmltest
 WORKDIR /test
-CMD [ "htmltest", "./"]
+ENTRYPOINT ["htmltest"]
+CMD ["./"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also build from sources by cloning this repo and running `sh build.sh`, 
 Mount your directory with html files into the container and test them.
 
 If you need more arguments to the test run it like this:  
-```docker run -v $(pwd):/test --rm wjdp/htmltest htmltest -l 3 -s```
+```docker run -v $(pwd):/test --rm wjdp/htmltest -l 3 -s```
 
 ### Notes
 


### PR DESCRIPTION
This change specifies htmltest as the ENTRYPOINT command in the Dockerfile. This change makes it so that Docker concatenates the ENTRYPOINT and the CMD. The big benefit is that clients don't have to redundantly type the binary name when they run the Docker image.

Instead of this:

docker run -v /home/mike/htmltest:/test --rm wjdp/htmltest htmltest -l 3 -s

they can leave out the second 'htmltest' like this:

docker run -v /home/mike/htmltest:/test --rm wjdp/htmltest -l 3 -s