### PR TITLE
Fix flaky test (TestAnchorExternalHrefIPTimeout)

### DIFF
--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -182,18 +182,6 @@ func (hT *HTMLTest) checkExternal(ref *htmldoc.Reference) {
 		<-hT.httpChannel // Bump off http concurrency limiter
 
 		if err != nil {
-			if strings.Contains(err.Error(), "dial tcp") {
-				// Remove long prefix
-				prefix := "Get " + urlStr + ": dial tcp: lookup "
-				cleanedMessage := strings.TrimPrefix(err.Error(), prefix)
-				// Add error
-				hT.issueStore.AddIssue(issues.Issue{
-					Level:     issueLevel,
-					Message:   cleanedMessage,
-					Reference: ref,
-				})
-				return
-			}
 			if strings.Contains(err.Error(), "Client.Timeout") {
 				hT.issueStore.AddIssue(issues.Issue{
 					Level:     issueLevel,
@@ -213,6 +201,20 @@ func (hT *HTMLTest) checkExternal(ref *htmldoc.Reference) {
 					})
 					return
 				}
+			}
+
+			// More generic, should be kept below more specific cases
+			if strings.Contains(err.Error(), "dial tcp") {
+				// Remove long prefix
+				prefix := "Get " + urlStr + ": dial tcp: lookup "
+				cleanedMessage := strings.TrimPrefix(err.Error(), prefix)
+				// Add error
+				hT.issueStore.AddIssue(issues.Issue{
+					Level:     issueLevel,
+					Message:   cleanedMessage,
+					Reference: ref,
+				})
+				return
 			}
 
 			// Unhandled client error, return generic error

--- a/htmltest/test_helpers_test.go
+++ b/htmltest/test_helpers_test.go
@@ -20,7 +20,7 @@ func tExpectIssue(t *testing.T, hT *HTMLTest, message string, expected int) {
 	c := hT.issueStore.MessageMatchCount(message)
 	if c != expected {
 		hT.issueStore.DumpIssues(true)
-		t.Error("expected issue", message, "count", expected, "!=", c)
+		t.Error("expected issue", "'"+message+"'", "count", expected, "!=", c)
 	}
 }
 


### PR DESCRIPTION
Sometimes the error message from http.Client is different in Go 1.15 for client timeouts.
The messages causing issues contain "dial tcp" which was caught before Client.Timeout.

This fix just moves the handler for "Client.Timeout" above "dial tcp".

Will close #148