### PR TITLE
Implement mailto email format checking (with url decoding)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/wjdp/htmltest
 
 require (
+	github.com/badoux/checkmail v1.2.1
 	github.com/daviddengcn/go-algs v0.0.0-20180330170136-fe23fabd9d06 // indirect
 	github.com/daviddengcn/go-assert v0.0.0-20150305222929-ba7e68aeeff6
 	github.com/daviddengcn/go-villa v0.0.0-20200811194146-68107afb6d76 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/badoux/checkmail v1.2.1 h1:TzwYx5pnsV6anJweMx2auXdekBwGr/yt1GgalIx9nBQ=
+github.com/badoux/checkmail v1.2.1/go.mod h1:XroCOBU5zzZJcLvgwU15I+2xXyCdTWXyR9MGfRhBYy0=
 github.com/daviddengcn/go-algs v0.0.0-20180330170136-fe23fabd9d06 h1:jEHTltplMBbYsHlSnvZD1J4CsfweUSJIqS8uP56q1Ng=
 github.com/daviddengcn/go-algs v0.0.0-20180330170136-fe23fabd9d06/go.mod h1:CpyLopUWBmqupyWU6OlSfrzgIuzNq0R6DXzM74O9RMs=
 github.com/daviddengcn/go-assert v0.0.0-20150305222929-ba7e68aeeff6 h1:OPIYL/VhQiSpoaxIcmeYdghLswBylfk6JDVCUqadXxg=

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -485,6 +485,19 @@ func TestMailtoValid(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
+func TestMailtoEncoded(t *testing.T) {
+	// ignores valid mailto links
+	hT := tTestFile("fixtures/links/mailto_encoded.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
+func TestMailtoEncodedInvalid(t *testing.T) {
+	// ignores valid mailto links
+	hT := tTestFile("fixtures/links/mailto_encoded_invalid.html")
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "cannot decode email (invalid URL escape \"%ZZ\")", 1)
+}
+
 func TestMailtoBlank(t *testing.T) {
 	// fails for blank mailto links
 	hT := tTestFile("fixtures/links/blank_mailto_link.html")
@@ -496,7 +509,7 @@ func TestMailtoInvalid(t *testing.T) {
 	// fails for invalid mailto links
 	hT := tTestFile("fixtures/links/invalid_mailto_link.html")
 	tExpectIssueCount(t, hT, 1)
-	tExpectIssue(t, hT, "contains an invalid email address", 1)
+	tExpectIssue(t, hT, "invalid email address (invalid format): 'octocat'", 1)
 }
 
 func TestMailtoIgnore(t *testing.T) {

--- a/htmltest/fixtures/links/mailto_encoded.html
+++ b/htmltest/fixtures/links/mailto_encoded.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+
+<a href="mailto:%75%72%64%74%40%76%61%66%65%72%2E%6F%72%67">Mail me</a>
+
+</body>
+
+</html>

--- a/htmltest/fixtures/links/mailto_encoded_invalid.html
+++ b/htmltest/fixtures/links/mailto_encoded_invalid.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+
+<a href="mailto:%75%72%64%74%40%76%61%ZZ%65%72%2E%6F%72%67">Mail me</a>
+
+</body>
+
+</html>


### PR DESCRIPTION
- We now check the format of emails using the https://github.com/badoux/checkmail package.
- We also decode the address which will fix #124.