### PR TITLE
Stop ignoring the content of pre / code tags

### DIFF
--- a/htmldoc/document.go
+++ b/htmldoc/document.go
@@ -91,8 +91,6 @@ func (doc *Document) parseNode(n *html.Node) {
 		case "base":
 			// Set BasePath from <base> tag
 			doc.BasePath = path.Join(doc.BasePath, GetAttr(n.Attr, "href"))
-		case "pre", "code":
-			return // Everything within these elements is not to be interpreted
 		}
 	case html.ErrorNode:
 		fmt.Printf("%+v\n", n)

--- a/htmldoc/document_test.go
+++ b/htmldoc/document_test.go
@@ -59,7 +59,7 @@ func TestDocumentNodesOfInterest(t *testing.T) {
 	}
 	doc.Init()
 	doc.Parse()
-	assert.Equals(t, "nodes of interest", len(doc.NodesOfInterest), 4)
+	assert.Equals(t, "nodes of interest", len(doc.NodesOfInterest), 12)
 }
 
 func TestDocumentBasePathDefault(t *testing.T) {

--- a/htmltest/check-img_test.go
+++ b/htmltest/check-img_test.go
@@ -200,10 +200,10 @@ func TestImageAltIgnoreMissingWithBlank(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
-func TestImagePre(t *testing.T) {
-	// works for broken images within pre & code
+func TestBrokenImagePre(t *testing.T) {
+	// we no longer ignore image issues in pre / code tags
 	hT := tTestFile("fixtures/images/badImagesInPre.html")
-	tExpectIssueCount(t, hT, 0)
+	tExpectIssueCount(t, hT, 16)
 }
 
 func TestImageUsemap(t *testing.T) {

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -360,6 +360,12 @@ func TestAnchorHashBrokenIgnore(t *testing.T) {
 	tExpectIssueCount(t, hT2, 0)
 }
 
+func TestAnchorHashInPre163(t *testing.T) {
+	// passes for valid self hash
+	hT := tTestFile("fixtures/links/hash-in-pre-163.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestAnchorDirectoryRootResolve(t *testing.T) {
 	// properly resolves implicit /index.html in link paths
 	hT := tTestFile("fixtures/links/linkToFolder.html")

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -615,15 +615,18 @@ func TestLinkRelDnsPrefetch(t *testing.T) {
 }
 
 func TestAnchorPre(t *testing.T) {
-	// works for broken anchors within pre & code
-	hT := tTestFile("fixtures/links/anchors_in_pre.html")
-	tExpectIssueCount(t, hT, 0)
+	// catches broken links when inside pre or code tags
+	hT := tTestFileOpts("fixtures/links/anchors_in_pre.html",
+		map[string]interface{}{"VCREnable": true})
+	tExpectIssueCount(t, hT, 2)
+	tExpectIssue(t, hT, "Non-OK status", 2)
 }
 
 func TestLinkPre(t *testing.T) {
-	// works for broken link within pre & code
+	// catches broken links when inside pre or code tags
 	hT := tTestFile("fixtures/links/links_in_pre.html")
-	tExpectIssueCount(t, hT, 0)
+	tExpectIssueCount(t, hT, 2)
+	tExpectIssue(t, hT, "href blank", 2)
 }
 
 func TestAnchorHashQueryBroken(t *testing.T) {

--- a/htmltest/check-script_test.go
+++ b/htmltest/check-script_test.go
@@ -70,9 +70,13 @@ func TestScriptContentAbsent(t *testing.T) {
 }
 
 func TestScriptInPre(t *testing.T) {
-	// works for broken script within pre & code
-	hT := tTestFile("fixtures/scripts/script_in_pre.html")
-	tExpectIssueCount(t, hT, 0)
+	// catches broken links when inside pre or code tags
+	hT := tTestFileOpts("fixtures/scripts/script_in_pre.html",
+		map[string]interface{}{"VCREnable": true})
+	tExpectIssueCount(t, hT, 4)
+	tExpectIssue(t, hT, "Non-OK status", 2)
+	tExpectIssue(t, hT, "script content missing", 2)
+
 }
 
 func TestScriptSrcIgnore(t *testing.T) {

--- a/htmltest/fixtures/images/badImagesInPre.html
+++ b/htmltest/fixtures/images/badImagesInPre.html
@@ -2,7 +2,6 @@
 <img src="./gpl.png" />
 <img src="./madeup.xyz" />
 <img src="   " />
-<img src="http://website.com/image.bmp" />
 <img alt="   " />
 <img alt="" />
 </pre>
@@ -11,7 +10,6 @@
 <img src="./gpl.png" />
 <img src="./madeup.xyz" />
 <img src="   " />
-<img src="http://website.com/image.bmp" />
 <img alt="   " />
 <img alt="" />
 </code>

--- a/htmltest/fixtures/links/hash-in-pre-163.html
+++ b/htmltest/fixtures/links/hash-in-pre-163.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+
+<pre><span id="A">1</span></pre>
+<a href="#A">1</a>
+
+<span id="B">2</span>
+<a href="#B">2</a>

--- a/htmltest/fixtures/scripts/script_in_pre.html
+++ b/htmltest/fixtures/scripts/script_in_pre.html
@@ -1,9 +1,9 @@
-<pre lang="html"><code><script src="https://embed.github.com/view/geojson/<username>/<repo>/<ref>/<path_to_file>"></script>
+<pre lang="html"><code><script src="https://embed.github.invalid/view/geojson/<username>/<repo>/<ref>/<path_to_file>"></script>
 </code></pre>
 
 <pre><script></script></pre>
 
-<code><script src="https://embed.github.com/view/geojson/<username>/<repo>/<ref>/<path_to_file>"></script>
+<code><script src="https://embed.github.invalid/view/geojson/<username>/<repo>/<ref>/<path_to_file>"></script>
 </code>
 
 <code><script></script></code>

--- a/htmltest/fixtures/vcr/links/anchors_in_pre.html.cassette
+++ b/htmltest/fixtures/vcr/links/anchors_in_pre.html.cassette
@@ -1,0 +1,94 @@
+{
+  "Name": "anchors_in_pre.html",
+  "Path": "fixtures/vcr/links",
+  "Tracks": [
+    {
+      "Request": {
+        "Method": "GET",
+        "URL": {
+          "Scheme": "http",
+          "Opaque": "",
+          "User": null,
+          "Host": "www.asdo3IRJ395295jsingrkrg4.com",
+          "Path": "",
+          "RawPath": "",
+          "ForceQuery": false,
+          "RawQuery": "",
+          "Fragment": "",
+          "RawFragment": ""
+        },
+        "Header": {
+          "Accept": [
+            "*/*"
+          ],
+          "Range": [
+            "bytes=0-0"
+          ],
+          "User-Agent": [
+            "htmltest/dev"
+          ]
+        },
+        "Body": ""
+      },
+      "Response": {
+        "Status": "",
+        "StatusCode": 0,
+        "Proto": "",
+        "ProtoMajor": 0,
+        "ProtoMinor": 0,
+        "Header": null,
+        "Body": null,
+        "ContentLength": 0,
+        "TransferEncoding": null,
+        "Trailer": null,
+        "TLS": null
+      },
+      "ErrType": "*net.OpError",
+      "ErrMsg": "dial tcp: lookup www.asdo3IRJ395295jsingrkrg4.com: no such host"
+    },
+    {
+      "Request": {
+        "Method": "GET",
+        "URL": {
+          "Scheme": "http",
+          "Opaque": "",
+          "User": null,
+          "Host": "www.asdo3IRJ395295jsingrkrg4.com",
+          "Path": "",
+          "RawPath": "",
+          "ForceQuery": false,
+          "RawQuery": "",
+          "Fragment": "",
+          "RawFragment": ""
+        },
+        "Header": {
+          "Accept": [
+            "*/*"
+          ],
+          "Range": [
+            "bytes=0-0"
+          ],
+          "User-Agent": [
+            "htmltest/dev"
+          ]
+        },
+        "Body": ""
+      },
+      "Response": {
+        "Status": "",
+        "StatusCode": 0,
+        "Proto": "",
+        "ProtoMajor": 0,
+        "ProtoMinor": 0,
+        "Header": null,
+        "Body": null,
+        "ContentLength": 0,
+        "TransferEncoding": null,
+        "Trailer": null,
+        "TLS": null
+      },
+      "ErrType": "*net.OpError",
+      "ErrMsg": "dial tcp: lookup www.asdo3IRJ395295jsingrkrg4.com: no such host"
+    }
+  ]
+}

--- a/htmltest/fixtures/vcr/scripts/script_in_pre.html.cassette
+++ b/htmltest/fixtures/vcr/scripts/script_in_pre.html.cassette
@@ -1,0 +1,94 @@
+{
+  "Name": "script_in_pre.html",
+  "Path": "fixtures/vcr/scripts",
+  "Tracks": [
+    {
+      "Request": {
+        "Method": "GET",
+        "URL": {
+          "Scheme": "https",
+          "Opaque": "",
+          "User": null,
+          "Host": "embed.github.invalid",
+          "Path": "/view/geojson/\u003cusername\u003e/\u003crepo\u003e/\u003cref\u003e/\u003cpath_to_file\u003e",
+          "RawPath": "",
+          "ForceQuery": false,
+          "RawQuery": "",
+          "Fragment": "",
+          "RawFragment": ""
+        },
+        "Header": {
+          "Accept": [
+            "*/*"
+          ],
+          "Range": [
+            "bytes=0-0"
+          ],
+          "User-Agent": [
+            "htmltest/dev"
+          ]
+        },
+        "Body": ""
+      },
+      "Response": {
+        "Status": "",
+        "StatusCode": 0,
+        "Proto": "",
+        "ProtoMajor": 0,
+        "ProtoMinor": 0,
+        "Header": null,
+        "Body": null,
+        "ContentLength": 0,
+        "TransferEncoding": null,
+        "Trailer": null,
+        "TLS": null
+      },
+      "ErrType": "*net.OpError",
+      "ErrMsg": "dial tcp: lookup embed.github.invalid: no such host"
+    },
+    {
+      "Request": {
+        "Method": "GET",
+        "URL": {
+          "Scheme": "https",
+          "Opaque": "",
+          "User": null,
+          "Host": "embed.github.invalid",
+          "Path": "/view/geojson/\u003cusername\u003e/\u003crepo\u003e/\u003cref\u003e/\u003cpath_to_file\u003e",
+          "RawPath": "",
+          "ForceQuery": false,
+          "RawQuery": "",
+          "Fragment": "",
+          "RawFragment": ""
+        },
+        "Header": {
+          "Accept": [
+            "*/*"
+          ],
+          "Range": [
+            "bytes=0-0"
+          ],
+          "User-Agent": [
+            "htmltest/dev"
+          ]
+        },
+        "Body": ""
+      },
+      "Response": {
+        "Status": "",
+        "StatusCode": 0,
+        "Proto": "",
+        "ProtoMajor": 0,
+        "ProtoMinor": 0,
+        "Header": null,
+        "Body": null,
+        "ContentLength": 0,
+        "TransferEncoding": null,
+        "Trailer": null,
+        "TLS": null
+      },
+      "ErrType": "*net.OpError",
+      "ErrMsg": "dial tcp: lookup embed.github.invalid: no such host"
+    }
+  ]
+}


### PR DESCRIPTION
Unsure where we got the idea to ignore HTML in `pre` and `code` tags. It was a mistake. This PR removes this exception and adjusts tests.

It will also fix #163 