### PR TITLE
Fix panic when referencing ignored directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ dist/
 
 # JetBrains config
 .idea/
+*.iml

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
-github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450 h1:7xqw01UYS+KCI25bMrPxwNYkSns2Db1ziQPpVq99FpE=
 github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
 github.com/golangplus/bytes v1.0.0 h1:YQKBijBVMsBxIiXT4IEhlKR2zHohjEqPole4umyDX+c=
 github.com/golangplus/bytes v1.0.0/go.mod h1:AdRaCFwmc/00ZzELMWb01soso6W1R/++O1XL80yAn+A=

--- a/htmldoc/document.go
+++ b/htmldoc/document.go
@@ -2,11 +2,12 @@ package htmldoc
 
 import (
 	"fmt"
-	"github.com/wjdp/htmltest/output"
-	"golang.org/x/net/html"
 	"os"
 	"path"
 	"sync"
+
+	"github.com/wjdp/htmltest/output"
+	"golang.org/x/net/html"
 )
 
 // Document struct, representation of a document within the tested site
@@ -14,6 +15,7 @@ type Document struct {
 	FilePath           string                // Relative to the shell session
 	SitePath           string                // Relative to the site root
 	BasePath           string                // Base for relative links
+	IgnoreTest         bool                  // Ignore this Document for testing.
 	htmlMutex          *sync.Mutex           // Controls access to htmlNode
 	htmlNode           *html.Node            // Parsed output
 	hashMap            map[string]*html.Node // Map of valid id/names of nodes
@@ -43,6 +45,7 @@ func (doc *Document) Init() {
 // already been done. Thread safe. Either called when the document is tested
 // or when another document needs data from this one.
 func (doc *Document) Parse() {
+
 	// Only one routine may parse the doc
 	doc.htmlMutex.Lock()
 	defer doc.htmlMutex.Unlock()

--- a/htmldoc/document_store.go
+++ b/htmldoc/document_store.go
@@ -4,10 +4,11 @@
 package htmldoc
 
 import (
-	"github.com/wjdp/htmltest/output"
 	"os"
 	"path"
 	"regexp"
+
+	"github.com/wjdp/htmltest/output"
 )
 
 // DocumentStore struct, store of Documents including Document discovery
@@ -55,11 +56,6 @@ func (dS *DocumentStore) isDirIgnored(dir string) bool {
 
 // Recursive function to discover documents by walking the file tree
 func (dS *DocumentStore) discoverRecurse(dPath string) {
-	// Recurse over relative path dPath, saves found documents to dS
-	if dS.isDirIgnored(dPath) {
-		return
-	}
-
 	// Open directory to scan
 	f, err := os.Open(path.Join(dS.BasePath, dPath))
 	output.CheckErrorPanic(err)
@@ -83,9 +79,10 @@ func (dS *DocumentStore) discoverRecurse(dPath string) {
 			} else if path.Ext(fileinfo.Name()) == dS.DocumentExtension {
 				// If a file, create and save document
 				newDoc := &Document{
-					FilePath: path.Join(dS.BasePath, fPath),
-					SitePath: fPath,
-					BasePath: dPath,
+					FilePath:   path.Join(dS.BasePath, fPath),
+					SitePath:   fPath,
+					BasePath:   dPath,
+					IgnoreTest: dS.isDirIgnored(dPath),
 				}
 				newDoc.Init()
 				dS.AddDocument(newDoc)

--- a/htmldoc/document_store_test.go
+++ b/htmldoc/document_store_test.go
@@ -1,8 +1,9 @@
 package htmldoc
 
 import (
-	"github.com/daviddengcn/go-assert"
 	"testing"
+
+	"github.com/daviddengcn/go-assert"
 )
 
 func TestDocumentStoreDiscover(t *testing.T) {
@@ -25,7 +26,7 @@ func TestDocumentStoreIgnorePatterns(t *testing.T) {
 	dS.IgnorePatterns = []interface{}{"^lib/"}
 	dS.Discover()
 	// Fixtures dir has seven documents in various folders, (one ignored in lib)
-	assert.Equals(t, "document count", len(dS.Documents), 5)
+	assert.Equals(t, "document count", len(dS.Documents), 6)
 }
 
 func TestDocumentStoreDocumentExists(t *testing.T) {

--- a/htmldoc/reference.go
+++ b/htmldoc/reference.go
@@ -1,10 +1,11 @@
 package htmldoc
 
 import (
-	"golang.org/x/net/html"
 	"net/url"
 	"path"
 	"strings"
+
+	"golang.org/x/net/html"
 )
 
 // Reference struct, representation of the link between a document and a
@@ -19,6 +20,7 @@ type Reference struct {
 // NewReference : Create a new reference given a document, node and path.
 // Generates the URL object.
 func NewReference(document *Document, node *html.Node, path string) (*Reference, error) {
+
 	// Clean path
 	path = strings.TrimLeftFunc(path, invalidPrePostRune)
 	path = strings.TrimRightFunc(path, invalidPrePostRune)

--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -333,8 +333,9 @@ func (hT *HTMLTest) checkInternalHash(ref *htmldoc.Reference) {
 
 	if len(ref.URL.Path) > 0 {
 		// internal
-		refDoc, _ := hT.documentStore.ResolveRef(ref)
-		if !refDoc.IsHashValid(ref.URL.Fragment) {
+		refDoc, ok := hT.documentStore.ResolveRef(ref)
+
+		if !ok || !refDoc.IsHashValid(ref.URL.Fragment) {
 			hT.issueStore.AddIssue(issues.Issue{
 				Level:     issues.LevelError,
 				Message:   "hash does not exist",

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -6,17 +6,18 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/wjdp/htmltest/htmldoc"
-	"github.com/wjdp/htmltest/issues"
-	"github.com/wjdp/htmltest/output"
-	"github.com/wjdp/htmltest/refcache"
-	"gopkg.in/seborama/govcr.v2"
 	"net/http"
 	"os"
 	"path"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wjdp/htmltest/htmldoc"
+	"github.com/wjdp/htmltest/issues"
+	"github.com/wjdp/htmltest/output"
+	"github.com/wjdp/htmltest/refcache"
+	"gopkg.in/seborama/govcr.v2"
 )
 
 // Base path for VCR cassettes, relative to this package
@@ -186,6 +187,14 @@ func (hT *HTMLTest) testDocuments() {
 }
 
 func (hT *HTMLTest) testDocument(document *htmldoc.Document) {
+	if document.IgnoreTest {
+		hT.issueStore.AddIssue(issues.Issue{
+			Level:   issues.LevelDebug,
+			Message: "ignored " + document.SitePath,
+		})
+		return
+	}
+
 	hT.issueStore.AddIssue(issues.Issue{
 		Level:   issues.LevelDebug,
 		Message: "testDocument on " + document.SitePath,


### PR DESCRIPTION
This fix includes two things:
1. Check for `ok` value from `ResolveRef` in `checkInternalHash`. If a value was ignored but was a valid link, it would panic as it was not found.
2. Change the behaviour of `discoverRecurse` such that it keeps all found `Document`s, but adds a new `IgnoreTest` attribute such that we can track if it should be skipped on test, but still referenced in a test.

Closes #126