### PR TITLE
Remove ignored child nodes in tree

### DIFF
--- a/htmldoc/document.go
+++ b/htmldoc/document.go
@@ -70,8 +70,13 @@ func (doc *Document) Parse() {
 // Internal recursive function that delves into the node tree and captures
 // nodes of interest and node id/names.
 func (doc *Document) parseNode(n *html.Node) {
-	// Ignore this tree if data-proofer-ignore set
+	// Remove this tree and ignore if data-proofer-ignore set
 	if doc.ignoreTagAttribute != "" && AttrPresent(n.Attr, doc.ignoreTagAttribute) {
+		var nextSibling *html.Node
+		for c := n.FirstChild; c != nil; c = nextSibling {
+			nextSibling = c.NextSibling
+			n.RemoveChild(c)
+		}
 		return
 	}
 


### PR DESCRIPTION
Helps to resolve memory issues such as #185 by removing child nodes from nodes where ignoreTagAttribute (data-proofer-ignore) is set.
This reduces the amount of memory needed by htmltest if large sections of documents (such as generated tables of contents) can be ignored. See linked issue for the use case.

(This PR will not be supported by Mendix, but is on a Mendix fork so it can be used on their own documentation site)