### PR TITLE
add details for blank href errors

### DIFF
--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -67,9 +67,16 @@ func (hT *HTMLTest) checkLink(document *htmldoc.Document, node *html.Node) {
 	// Blank href
 	if attrs["href"] == "" {
 		if !hT.opts.IgnoreEmptyHref {
+			var msg string = "href blank"
+			if attrs["title"] != "" {
+				msg = fmt.Sprintf("%s title=%q", msg, attrs["title"])
+			}
+			if ref.Node.FirstChild != nil {
+				msg = fmt.Sprintf("%s body=%q", msg, ref.Node.FirstChild.Data)
+			}
 			hT.issueStore.AddIssue(issues.Issue{
 				Level:     issues.LevelError,
-				Message:   "href blank",
+				Message:   msg,
 				Reference: ref,
 			})
 		}


### PR DESCRIPTION
In large HTML files finding the blank href attributes in anchor tags
can be difficult. This change adds more details like the title and
body of the anchor to the error message to make it more obvious which
link is broken.