### PR TITLE
IgnoreAltEmpty option for alt="" decorative images

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |
 | `IgnoreExternalBrokenLinks` | When true produces a warning, rather than an error, for broken external links. Useful when testing a site having hundreds of external links. | `false` |
 | `IgnoreAltMissing` | Turns off image alt attribute checking. | `false` |
+| `IgnoreAltEmpty` | Allows `alt=""` for decorative images. | `false` |
 | `IgnoreDirectoryMissingTrailingSlash` | Turns off errors for links to directories without a trailing slash. | `false` |
 | `IgnoreSSLVerify` | Turns off x509 errors for self-signed certificates. | `false` |
 | `IgnoreTagAttribute` | Specify the ignore attribute. All tags with this attribute will be excluded from every check. | `"data-proofer-ignore"` |

--- a/htmltest/check-img.go
+++ b/htmltest/check-img.go
@@ -32,7 +32,7 @@ func (hT *HTMLTest) checkImg(document *htmldoc.Document, node *html.Node) {
 		})
 	} else if htmldoc.AttrPresent(node.Attr, "alt") && !hT.opts.IgnoreAltMissing {
 		// Following checks require alt attr is present
-		if len(attrs["alt"]) == 0 {
+		if len(attrs["alt"]) == 0 && !hT.opts.IgnoreAltEmpty {
 			// Check alt has length, fail if empty
 			hT.issueStore.AddIssue(issues.Issue{
 				Level:     issues.LevelError,

--- a/htmltest/check-img_test.go
+++ b/htmltest/check-img_test.go
@@ -179,6 +179,21 @@ func TestImageAltEmpty(t *testing.T) {
 	tExpectIssue(t, hT, "alt text empty", 1)
 }
 
+func TestImageAltIgnoreEmptyWhenMissing(t *testing.T) {
+	// fails for image with an empty alt attribute
+	hT := tTestFileOpts("fixtures/images/missingImageAlt.html",
+		map[string]interface{}{"IgnoreAltEmpty": true})
+	tExpectIssueCount(t, hT, 1)
+	tExpectIssue(t, hT, "alt attribute missing", 1)
+}
+
+func TestImageAltIgnoreEmptyWhenPresent(t *testing.T) {
+	// ignores empty alt attribute present for image
+	hT := tTestFileOpts("fixtures/images/emptyImageAltTextExplicit.html",
+		map[string]interface{}{"IgnoreAltEmpty": true})
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestImageAltSpaces(t *testing.T) {
 	// fails for image with nothing but spaces in alt attribute
 	hT := tTestFile("fixtures/images/emptyImageAltText.html")

--- a/htmltest/fixtures/images/emptyImageAltTextExplicit.html
+++ b/htmltest/fixtures/images/emptyImageAltTextExplicit.html
@@ -1,0 +1,9 @@
+
+
+<body>
+
+	<p>Blah blah blah. <img src="./gpl.png" alt=""/> </p>
+	<p>Blah blah blah. <img src="./gpl.png" alt/> </p>
+</body>
+
+</html>

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -48,6 +48,7 @@ type Options struct {
 	IgnoreCanonicalBrokenLinks          bool
 	IgnoreExternalBrokenLinks           bool
 	IgnoreAltMissing                    bool
+	IgnoreAltEmpty                      bool
 	IgnoreDirectoryMissingTrailingSlash bool
 	IgnoreSSLVerify                     bool
 	IgnoreTagAttribute                  string
@@ -114,6 +115,7 @@ func DefaultOptions() map[string]interface{} {
 		"IgnoreCanonicalBrokenLinks":          true,
 		"IgnoreExternalBrokenLinks":           false,
 		"IgnoreAltMissing":                    false,
+		"IgnoreAltEmpty":                      false,
 		"IgnoreDirectoryMissingTrailingSlash": false,
 		"IgnoreSSLVerify":                     false,
 		"IgnoreTagAttribute":                  "data-proofer-ignore",


### PR DESCRIPTION
Introduces a new configuration option, `IgnoreAltEmpty` for allowing alt attribute checks against images, while being more lenient with explicit empty alt attributes.  WAI instructs HTML practitioners to set an explicitly empty alt attribute for decorative images that offer no additional context or meaningful information to a page, so that they can be skipped by screen readers:

https://www.w3.org/WAI/tutorials/images/decorative/

Fixes #153

I have been using this on my own fork to validate https://vivanti.com/