### PR TITLE
Add possibility to ignore based on existing class

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ I'd like to test the following but won't be for a while.
 
 ## :see_no_evil: Ignoring content
 
-Add the `data-proofer-ignore` attribute to any tag to ignore it from every check. The name of this attribute can be customised.
+Add the `data-proofer-ignore` attribute to any tag or to the class of a tag to ignore it from every check. The name of this attribute can be customised.
 
 ```html
 <a href="http://notareallink" data-proofer-ignore>Not checked.</a>
@@ -129,55 +129,55 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 
 ### Basic Options
 
-| Option | Description | Default |
-| :----- | :---------- | :------ |
-| `DirectoryPath` | Directory to scan for HTML files. | |
-| `DirectoryIndex` | The file to look for when linking to a directory. | `index.html` |
-| `FilePath` | Single file to test within `DirectoryPath`, omit to test all. | |
-| `FileExtension` | Extension of your HTML documents, includes the dot. If `FilePath` is set we use the extension from that. | `.html` |
-| `CheckDoctype` | Enables checking the document type declaration. | `true` |
-| `CheckAnchors` | Enables checking `<a…` tags. | `true` |
-| `CheckLinks` | Enables checking `<link…` tags. | `true` |
-| `CheckImages` | Enables checking `<img…` tags | `true` |
-| `CheckScripts` | Enables checking `<script…` tags. | `true` |
-| `CheckMeta` | Enables checking `<meta…` tags. | `true` |
-| `CheckGeneric` | Enables other tags, see items marked with checkGeneric on the [tags wiki page](https://github.com/wjdp/htmltest/wiki/Tags). | `true` |
-| `CheckExternal` | Enables external reference checking; all tag types. | `true` |
+| Option | Description                                                                                                                                                                                                     | Default |
+| :----- |:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| :------ |
+| `DirectoryPath` | Directory to scan for HTML files.                                                                                                                                                                               | |
+| `DirectoryIndex` | The file to look for when linking to a directory.                                                                                                                                                               | `index.html` |
+| `FilePath` | Single file to test within `DirectoryPath`, omit to test all.                                                                                                                                                   | |
+| `FileExtension` | Extension of your HTML documents, includes the dot. If `FilePath` is set we use the extension from that.                                                                                                        | `.html` |
+| `CheckDoctype` | Enables checking the document type declaration.                                                                                                                                                                 | `true` |
+| `CheckAnchors` | Enables checking `<a…` tags.                                                                                                                                                                                    | `true` |
+| `CheckLinks` | Enables checking `<link…` tags.                                                                                                                                                                                 | `true` |
+| `CheckImages` | Enables checking `<img…` tags                                                                                                                                                                                   | `true` |
+| `CheckScripts` | Enables checking `<script…` tags.                                                                                                                                                                               | `true` |
+| `CheckMeta` | Enables checking `<meta…` tags.                                                                                                                                                                                 | `true` |
+| `CheckGeneric` | Enables other tags, see items marked with checkGeneric on the [tags wiki page](https://github.com/wjdp/htmltest/wiki/Tags).                                                                                     | `true` |
+| `CheckExternal` | Enables external reference checking; all tag types.                                                                                                                                                             | `true` |
 | `CheckInternal` | Enables internal reference checking; all tag types. When disabled will prevent internal hash checking unless the reference only contains a hash fragment (`#heading`) and therefore refers to the current page. | `true` |
-| `CheckInternalHash` | Enables internal hash/fragment checking. | `true` |
-| `CheckMailto` | Enables–albeit quite basic–`mailto:` link checking. | `true` |
-| `CheckTel` | Enables–albeit quite basic–`tel:` link checking. | `true` |
-| `CheckFavicon` | Enables favicon checking, ensures every page has a favicon set. | `false` |
-| `CheckMetaRefresh` | Enables checking meta refresh tags. | `true` |
-| `EnforceHTML5` | Fails when the doctype isn't `<!DOCTYPE html>`. | `false` |
-| `EnforceHTTPS` | Fails when encountering an `http://` link. Useful to prevent mixed content errors when serving over HTTPS. | `false` |
-| `IgnoreURLs` | Array of regexs of URLs to ignore. | empty |
-| `IgnoreInternalURLs` | Array of strings of internal URLs to ignore. Exact matches only. ⚠ Likely to be deprecated, use `IgnoreURLs` instead. | empty |
-| `IgnoreHTTPS` | Array of regexs of URLs to ignore for `EnforceHTTPS`. These URLs are still tested, unless also present in `IgnoreURLs`. | empty |
-| `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files. | empty |
-| `IgnoreInternalEmptyHash` | When true prevents raising an error for links with `href="#"`. | `false` |
-| `IgnoreEmptyHref` | When true prevents raising an error for links with `href=""`. | `false` |
-| `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail. | `true` |
-| `IgnoreExternalBrokenLinks` | When true produces a warning, rather than an error, for broken external links. Useful when testing a site having hundreds of external links. | `false` |
-| `IgnoreAltMissing` | Turns off image alt attribute checking. | `false` |
-| `IgnoreAltEmpty` | Allows `alt=""` for decorative images. | `false` |
-| `IgnoreDirectoryMissingTrailingSlash` | Turns off errors for links to directories without a trailing slash. | `false` |
-| `IgnoreSSLVerify` | Turns off x509 errors for self-signed certificates. | `false` |
-| `IgnoreTagAttribute` | Specify the ignore attribute. All tags with this attribute will be excluded from every check. | `"data-proofer-ignore"` |
-| `HTTPHeaders` | Dictionary of headers to include in external requests | `{"Range":  "bytes=0-0", "Accept": "*/*"}` |
-| `TestFilesConcurrently` | :warning: :construction: *EXPERIMENTAL* Turns on [concurrent](https://github.com/wjdp/htmltest/wiki/Concurrency) checking of files. | `false` |
-| `DocumentConcurrencyLimit` | Maximum number of documents to process at once. | `128` |
-| `HTTPConcurrencyLimit` | Maximum number of open HTTP connections. If you raise this number ensure the `ExternalTimeout` is suitably raised. | `16` |
-| `LogLevel` | Logging level, 0-3: debug, info, warning, error. | `2` |
-| `LogSort` | How to sort/present issues. Can be `seq` for sequential output or `document` to group by document. | `document` |
-| `ExternalTimeout` | Number of seconds to wait on an HTTP connection before failing. | `15` |
-| `RedirectLimit` | Allowed number of redirects. Use built-in behavior with negative values. | `-1` |
-| `StripQueryString` | Enables stripping of query strings from external checks. | `true` |
-| `StripQueryExcludes` | List of URLs to disable query stripping on. | `["fonts.googleapis.com"]` |
-| `OutputDir` | Directory to store cache and log files in. Relative to executing directory. | `tmp/.htmltest` |
-| `OutputCacheFile` | File within `OutputDir` to store reference cache. | `refcache.json` |
-| `OutputLogFile` | File within `OutputDir` to store last tests errors. | `htmltest.log` |
-| `CacheExpires` | Cache validity period, accepts [go.time duration strings](https://golang.org/pkg/time/#ParseDuration) (…"m", "h"). | `336h` (two weeks) |
+| `CheckInternalHash` | Enables internal hash/fragment checking.                                                                                                                                                                        | `true` |
+| `CheckMailto` | Enables–albeit quite basic–`mailto:` link checking.                                                                                                                                                             | `true` |
+| `CheckTel` | Enables–albeit quite basic–`tel:` link checking.                                                                                                                                                                | `true` |
+| `CheckFavicon` | Enables favicon checking, ensures every page has a favicon set.                                                                                                                                                 | `false` |
+| `CheckMetaRefresh` | Enables checking meta refresh tags.                                                                                                                                                                             | `true` |
+| `EnforceHTML5` | Fails when the doctype isn't `<!DOCTYPE html>`.                                                                                                                                                                 | `false` |
+| `EnforceHTTPS` | Fails when encountering an `http://` link. Useful to prevent mixed content errors when serving over HTTPS.                                                                                                      | `false` |
+| `IgnoreURLs` | Array of regexs of URLs to ignore.                                                                                                                                                                              | empty |
+| `IgnoreInternalURLs` | Array of strings of internal URLs to ignore. Exact matches only. ⚠ Likely to be deprecated, use `IgnoreURLs` instead.                                                                                           | empty |
+| `IgnoreHTTPS` | Array of regexs of URLs to ignore for `EnforceHTTPS`. These URLs are still tested, unless also present in `IgnoreURLs`.                                                                                         | empty |
+| `IgnoreDirs` | Array of regexs of directories to ignore when scanning for HTML files.                                                                                                                                          | empty |
+| `IgnoreInternalEmptyHash` | When true prevents raising an error for links with `href="#"`.                                                                                                                                                  | `false` |
+| `IgnoreEmptyHref` | When true prevents raising an error for links with `href=""`.                                                                                                                                                   | `false` |
+| `IgnoreCanonicalBrokenLinks` | When true produces a warning, rather than an error, for broken canonical links. When testing a site which isn't live yet or before publishing a new page canonical links will fail.                             | `true` |
+| `IgnoreExternalBrokenLinks` | When true produces a warning, rather than an error, for broken external links. Useful when testing a site having hundreds of external links.                                                                    | `false` |
+| `IgnoreAltMissing` | Turns off image alt attribute checking.                                                                                                                                                                         | `false` |
+| `IgnoreAltEmpty` | Allows `alt=""` for decorative images.                                                                                                                                                                          | `false` |
+| `IgnoreDirectoryMissingTrailingSlash` | Turns off errors for links to directories without a trailing slash.                                                                                                                                             | `false` |
+| `IgnoreSSLVerify` | Turns off x509 errors for self-signed certificates.                                                                                                                                                             | `false` |
+| `IgnoreTagAttribute` | Specify the ignore attribute. All tags with this attribute or with this class will be excluded from every check.                                                                                                | `"data-proofer-ignore"` |
+| `HTTPHeaders` | Dictionary of headers to include in external requests                                                                                                                                                           | `{"Range":  "bytes=0-0", "Accept": "*/*"}` |
+| `TestFilesConcurrently` | :warning: :construction: *EXPERIMENTAL* Turns on [concurrent](https://github.com/wjdp/htmltest/wiki/Concurrency) checking of files.                                                                             | `false` |
+| `DocumentConcurrencyLimit` | Maximum number of documents to process at once.                                                                                                                                                                 | `128` |
+| `HTTPConcurrencyLimit` | Maximum number of open HTTP connections. If you raise this number ensure the `ExternalTimeout` is suitably raised.                                                                                              | `16` |
+| `LogLevel` | Logging level, 0-3: debug, info, warning, error.                                                                                                                                                                | `2` |
+| `LogSort` | How to sort/present issues. Can be `seq` for sequential output or `document` to group by document.                                                                                                              | `document` |
+| `ExternalTimeout` | Number of seconds to wait on an HTTP connection before failing.                                                                                                                                                 | `15` |
+| `RedirectLimit` | Allowed number of redirects. Use built-in behavior with negative values.                                                                                                                                        | `-1` |
+| `StripQueryString` | Enables stripping of query strings from external checks.                                                                                                                                                        | `true` |
+| `StripQueryExcludes` | List of URLs to disable query stripping on.                                                                                                                                                                     | `["fonts.googleapis.com"]` |
+| `OutputDir` | Directory to store cache and log files in. Relative to executing directory.                                                                                                                                     | `tmp/.htmltest` |
+| `OutputCacheFile` | File within `OutputDir` to store reference cache.                                                                                                                                                               | `refcache.json` |
+| `OutputLogFile` | File within `OutputDir` to store last tests errors.                                                                                                                                                             | `htmltest.log` |
+| `CacheExpires` | Cache validity period, accepts [go.time duration strings](https://golang.org/pkg/time/#ParseDuration) (…"m", "h").                                                                                              | `336h` (two weeks) |
 
 ### Example
 

--- a/htmldoc/attr.go
+++ b/htmldoc/attr.go
@@ -2,6 +2,7 @@ package htmldoc
 
 import (
 	"golang.org/x/net/html"
+	"strings"
 )
 
 // GetAttr : From attrs extract single attr
@@ -33,6 +34,15 @@ func ExtractAttrs(attrs []html.Attribute, keys []string) map[string]string {
 func AttrPresent(attrs []html.Attribute, key string) bool {
 	for _, attr := range attrs {
 		if attr.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func ClassPresent(attrs []html.Attribute, class string) bool {
+	for _, attr := range attrs {
+		if attr.Key == "class" && strings.Contains(attr.Val, class) {
 			return true
 		}
 	}

--- a/htmldoc/document.go
+++ b/htmldoc/document.go
@@ -71,7 +71,8 @@ func (doc *Document) Parse() {
 // nodes of interest and node id/names.
 func (doc *Document) parseNode(n *html.Node) {
 	// Ignore this tree if data-proofer-ignore set
-	if doc.ignoreTagAttribute != "" && AttrPresent(n.Attr, doc.ignoreTagAttribute) {
+	if doc.ignoreTagAttribute != "" &&
+		(AttrPresent(n.Attr, doc.ignoreTagAttribute) || ClassPresent(n.Attr, doc.ignoreTagAttribute)) {
 		return
 	}
 

--- a/htmltest/fixtures/links/ignorableLinks.html
+++ b/htmltest/fixtures/links/ignorableLinks.html
@@ -8,6 +8,8 @@
 
 <a href="../whaadadt.html" data-proofer-ignore>Relative to nothing</a>
 
+<a href="../whaadadt.html" class="data-proofer-ignore">Relative to nothing</a>
+
 </body>
 
 </html>

--- a/htmltest/fixtures/links/ignorableLinksChildren.html
+++ b/htmltest/fixtures/links/ignorableLinksChildren.html
@@ -21,6 +21,15 @@
     </article>
 </section>
 
+<section>
+    <article class="data-proofer-ignore">
+        <div>
+            <span>
+                <a href="../whaadadt.html">Relative to nothing</a>
+            </span>
+        </div>
+    </article>
+</section>
 </body>
 
 </html>


### PR DESCRIPTION
Ingoring by tag attribute is helpful, but eg. docusaurus does not offer a good way to manipulate its theme. But it offers a way to always attach a custom class.

With this approach, we will reuse the IgnoreTagAttribute as a class name detection.

It isn't worth specifying an additional attribute for this use case, although the naming might be off now.

_Disclaimer_
I did not find a contributing guide, so I went ahead and created this pr. If you prefer to discuss this first in an issue, I will also gladly create one.
