### PR TITLE
[CI] Upgrade GH actions to avoid CI deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,21 @@ name: build
 on: [push, pull_request]
 
 env:
-  GO_VERSION: 1.17.8
+  GO_VERSION: 1.21.4
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - uses: pre-commit/action@v2.0.3
 
   git-describe:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Fetch tags
@@ -32,9 +32,9 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Run unit tests
@@ -49,13 +49,13 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Fetch tags
         run: git fetch --force --tags
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Set binary name
@@ -63,7 +63,7 @@ jobs:
       - name: Build
         run: go build -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=`git describe --tags`" -o bin/$BINARY_NAME -x main.go
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.BINARY_NAME }}
           path: bin/${{ env.BINARY_NAME }}
@@ -81,9 +81,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: gofmt
@@ -95,13 +95,13 @@ jobs:
     needs: [ test, build ]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Fetch tags
         run: git fetch --force --tags
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Run GoReleaser
@@ -120,7 +120,7 @@ jobs:
       DOCKER_REPO: wjdp/htmltest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Fetch tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.8
+ARG GO_VERSION=1.21.4
 ARG TARGET=alpine:3.9
 
 FROM golang:${GO_VERSION}-alpine AS builder


### PR DESCRIPTION
- Fixes #225
- Upgrades all [GitHub Actions](https://github.com/actions), used in `ci.yml`, to their latest versions
- Upgrades `GO_VERSION` to 1.21.4
