### PR TITLE
Report accurate tested-doc count

### DIFF
--- a/htmldoc/document_store.go
+++ b/htmldoc/document_store.go
@@ -30,6 +30,22 @@ func NewDocumentStore() DocumentStore {
 	}
 }
 
+// DocumentCount : Return number of documents in the document store.
+func (dS *DocumentStore) DocumentCount() int {
+	return len(dS.Documents)
+}
+
+// IgnoredDocCount : Return number of documents in the document store where `IgnoreTest` is true.
+func (dS *DocumentStore) IgnoredDocCount() int {
+	count := 0
+	for _, document := range dS.Documents {
+		if document.IgnoreTest {
+			count++
+		}
+	}
+	return count
+}
+
 // AddDocument : Add a document to the document store.
 func (dS *DocumentStore) AddDocument(doc *Document) {
 	// Save reference to document to various data stores
@@ -70,6 +86,8 @@ func (dS *DocumentStore) discoverRecurse(dPath string) {
 		fis, err := f.Readdir(-1)
 		output.CheckErrorPanic(err)
 
+		isDirIgnored := dS.isDirIgnored(dPath)
+
 		// Iterate over contents of directory
 		for _, fileinfo := range fis {
 			fPath := path.Join(dPath, fileinfo.Name())
@@ -82,7 +100,7 @@ func (dS *DocumentStore) discoverRecurse(dPath string) {
 					FilePath:   path.Join(dS.BasePath, fPath),
 					SitePath:   fPath,
 					BasePath:   dPath,
-					IgnoreTest: dS.isDirIgnored(dPath),
+					IgnoreTest: isDirIgnored,
 				}
 				newDoc.Init()
 				dS.AddDocument(newDoc)
@@ -94,7 +112,7 @@ func (dS *DocumentStore) discoverRecurse(dPath string) {
 
 }
 
-// ResolvePath : Resolves internal absolute paths to documents.
+// ResolvePath : Resolves internal paths to documents.
 func (dS *DocumentStore) ResolvePath(refPath string) (*Document, bool) {
 	// Match root document
 	if refPath == "/" {

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -298,5 +298,10 @@ func (hT *HTMLTest) CountErrors() int {
 
 // CountDocuments : Return number of documents in hT document store
 func (hT *HTMLTest) CountDocuments() int {
-	return len(hT.documentStore.Documents)
+	return hT.documentStore.DocumentCount()
+}
+
+// CountTestedDocuments : Return number of documents in hT document store that were tested
+func (hT *HTMLTest) CountTestedDocuments() int {
+	return hT.documentStore.DocumentCount() - hT.documentStore.IgnoredDocCount()
 }

--- a/htmltest/htmltest_test.go
+++ b/htmltest/htmltest_test.go
@@ -84,7 +84,8 @@ func TestNormalLookingPage(t *testing.T) {
 
 func TestCountDocuments(t *testing.T) {
 	hT := tTestDirectory("fixtures/documents/folder-ok")
-	assert.Equals(t, "CountDocuments", hT.CountDocuments(), 3)
+	assert.Equals(t, "CountTestedDocuments", hT.CountTestedDocuments(), 3)
+	assert.Equals(t, "CountErrors", hT.CountErrors(), 0)
 }
 
 func TestCountErrors(t *testing.T) {
@@ -105,7 +106,7 @@ func TestFileExtensionOption(t *testing.T) {
 		"FileExtension":  ".htm",
 		"DirectoryIndex": "index.htm",
 	})
-	assert.Equals(t, "CountDocuments", hT.CountDocuments(), 3)
+	assert.Equals(t, "CountTestedDocuments", hT.CountTestedDocuments(), 3)
 	tExpectIssueCount(t, hT, 1)
 }
 

--- a/main.go
+++ b/main.go
@@ -175,7 +175,14 @@ func run(options optsMap) int {
 		color.Set(color.FgHiGreen)
 		fmt.Println("✔✔✔ passed in", timeEnd.Sub(timeStart))
 		if !fileMode {
-			fmt.Println("tested", hT.CountDocuments(), "documents")
+			testedDocCount := hT.CountTestedDocuments()
+			fmt.Print("tested ", testedDocCount, " documents")
+			docCount := hT.CountDocuments()
+			if testedDocCount < docCount {
+				fmt.Println(" out of", docCount)
+			} else {
+				fmt.Println()
+			}
 		}
 		color.Unset()
 		return 0


### PR DESCRIPTION
- Fixes #227
- Fixes #228
- Document store: adds `DocumentCount()` and `IgnoredDocCount()` functions
- Reports the number of tested docs "out of" the full doc count when some documents are ignored
- Adjusts `TestDocumentStoreIgnorePatterns` test to check tested-doc count vs just the doc count, and adds a clarifying comment that `IgnorePatterns` doesn't affect stored document count