### PR TITLE
Add support for `--test-only DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options:
   -l LEVEL, --log-level LEVEL  Logging level, 0-3: debug, info, warning, error.
   -s, --skip-external          Skip external link checks, may shorten execution
                                time considerably.
+  -t, --test-only DIR          Site subdirectory to test, relative to the site base path
   -v, --version                Show version and build time.
 ```
 
@@ -135,6 +136,7 @@ htmltest uses a YAML configuration file. Put `.htmltest.yml` in the same directo
 | `DirectoryIndex` | The file to look for when linking to a directory.                                                                                                                                                               | `index.html` |
 | `FilePath` | Single file to test within `DirectoryPath`, omit to test all.                                                                                                                                                   | |
 | `FileExtension` | Extension of your HTML documents, includes the dot. If `FilePath` is set we use the extension from that.                                                                                                        | `.html` |
+| `TestOnlyDir` | Single directory to test within `DirectoryPath`, omit to test all.                                                                                                                                                   | |
 | `CheckDoctype` | Enables checking the document type declaration.                                                                                                                                                                 | `true` |
 | `CheckAnchors` | Enables checking `<a…` tags.                                                                                                                                                                                    | `true` |
 | `CheckLinks` | Enables checking `<link…` tags.                                                                                                                                                                                 | `true` |

--- a/htmldoc/document_store.go
+++ b/htmldoc/document_store.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/wjdp/htmltest/output"
 )
@@ -15,6 +16,7 @@ import (
 type DocumentStore struct {
 	BasePath           string               // Path, relative to cwd, the site is located in
 	IgnorePatterns     []interface{}        // Regexes of directories to ignore
+	TestOnlyDir        string               // Clean non-nil path of directory to test relative to `BasePath`
 	Documents          []*Document          // All of the documents, used to iterate over
 	DocumentPathMap    map[string]*Document // Maps slash separated paths to documents
 	DocumentExtension  string               // File extension to look for
@@ -50,6 +52,10 @@ func (dS *DocumentStore) isDirIgnored(dir string) bool {
 		if ok, _ := regexp.MatchString(item.(string), dir+"/"); ok {
 			return true
 		}
+	}
+	if dS.TestOnlyDir != "" {
+		matchesTestOnlyDir := strings.HasPrefix(dir, dS.TestOnlyDir)
+		return !matchesTestOnlyDir
 	}
 	return false
 }

--- a/htmldoc/document_store_test.go
+++ b/htmldoc/document_store_test.go
@@ -29,6 +29,28 @@ func TestDocumentStoreIgnorePatterns(t *testing.T) {
 	assert.Equals(t, "document count", len(dS.Documents), 6)
 }
 
+func TestDocumentStoreTestOnlyDir(t *testing.T) {
+	dS := NewDocumentStore()
+	dS.BasePath = "fixtures/documents"
+	dS.DocumentExtension = ".html" // Ignores .htm
+	dS.DirectoryIndex = "index.html"
+	dS.TestOnlyDir = "dir1"
+	dS.Discover()
+	// TestOnlyDir does not affect stored document count
+	assert.Equals(t, "document count", len(dS.Documents), 6)
+	// TODO: uncomment the following if/once https://github.com/wjdp/htmltest/pull/229 is merged
+	// assert.Equals(t, "ignored document count", dS.IgnoredDocCount(), 4)
+	ignoredFile := "dir2/index.html"
+	assert.IsTrue(t, ignoredFile+" is ignored", dS.DocumentPathMap[ignoredFile].IgnoreTest)
+
+	testFiles := [2]string{"dir1/index.html", "dir1/dir11/index.html"}
+	for _, keptFile := range testFiles {
+		f, exists := dS.DocumentPathMap[keptFile]
+		assert.IsTrue(t, keptFile+" exists", exists)
+		assert.IsFalse(t, keptFile+" is not ignored", f.IgnoreTest)
+	}
+}
+
 func TestDocumentStoreDocumentExists(t *testing.T) {
 	// documentstore knows if documents exist or not
 	dS := NewDocumentStore()

--- a/htmltest/htmltest.go
+++ b/htmltest/htmltest.go
@@ -149,6 +149,7 @@ func Test(optsUser map[string]interface{}) (*HTMLTest, error) {
 	hT.documentStore.DirectoryIndex = hT.opts.DirectoryIndex
 	hT.documentStore.IgnorePatterns = hT.opts.IgnoreDirs
 	hT.documentStore.IgnoreTagAttribute = hT.opts.IgnoreTagAttribute
+	hT.documentStore.TestOnlyDir = hT.opts.TestOnlyDir
 	// Discover documents
 	hT.documentStore.Discover()
 

--- a/htmltest/htmltest_test.go
+++ b/htmltest/htmltest_test.go
@@ -92,6 +92,16 @@ func TestCountErrors(t *testing.T) {
 	assert.Equals(t, "CountErrors", hT.CountErrors(), 2)
 }
 
+func TestCountFolderDocuments(t *testing.T) {
+	hT := tTestDirectoryOpts("fixtures/documents/folder-ok", map[string]interface{}{
+		"TestOnlyDir": "a",
+	})
+	assert.Equals(t, "CountDocuments", hT.CountDocuments(), 3)
+	// TODO: uncomment the following if/once https://github.com/wjdp/htmltest/pull/229 is merged
+	// assert.Equals(t, "CountTestedDocuments", hT.CountTestedDocuments(), 1)
+	assert.Equals(t, "CountErrors", hT.CountErrors(), 0)
+}
+
 func TestFileExtensionDefault(t *testing.T) {
 	// Non .html files are ignored
 	hT := tTestDirectory("fixtures/documents/folder-htm")

--- a/htmltest/options.go
+++ b/htmltest/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	DirectoryIndex string
 	FilePath       string
 	FileExtension  string
+	TestOnlyDir    string
 
 	CheckDoctype bool
 	CheckAnchors bool
@@ -86,6 +87,7 @@ func DefaultOptions() map[string]interface{} {
 	return map[string]interface{}{
 		"DirectoryIndex": "index.html",
 		"FileExtension":  ".html",
+		"TestOnlyDir":    "",
 
 		"CheckDoctype": true,
 		"CheckAnchors": true,


### PR DESCRIPTION
- A **simple feature** enhancement that adds CLI support for `--test-only DIR`
- Adds unit tests for the document store and htmltest
- (This feature will work best if/once #229 is merged, but I've kept is separate for now so that the PR diff is minimal.)