### PR TITLE
release: multi-platform docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
         with:
           push: true
           tags: ${{ env.DOCKER_REPO }}:${{ env.GIT_VERSION }}
+          platforms: linux/amd64,linux/arm64
           cache-from: ${{ env.DOCKER_REPO }}:latest
           build-args: |
             VERSION=${{ env.GIT_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 ARG GO_VERSION=1.21.4
 ARG TARGET=alpine:3.9
 
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
+ARG TARGETARCH
+ARG TARGETOS
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 RUN apk add --no-cache ca-certificates git
 


### PR DESCRIPTION
I noticed that the Docker Hub image was only built for amd64.
This adds a linux/arm64 platform variant to the Docker image,
which makes htmltest run faster (no emulation) on ARM-based systems.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
