### PR TITLE
Fix mailto URIs with multiple recipients

### DIFF
--- a/htmltest/check-link.go
+++ b/htmltest/check-link.go
@@ -405,23 +405,26 @@ func (hT *HTMLTest) checkMailto(ref *htmldoc.Reference) {
 		})
 		return
 	}
-	emailAddress, decodeErr := url.QueryUnescape(ref.URL.Opaque)
-	if decodeErr != nil {
-		hT.issueStore.AddIssue(issues.Issue{
-			Level:     issues.LevelError,
-			Message:   fmt.Sprintf("cannot decode email (%s): '%s'", decodeErr, ref.URL.Opaque),
-			Reference: ref,
-		})
-		return
-	}
-	formatErr := checkmail.ValidateFormat(emailAddress)
-	if formatErr != nil {
-		hT.issueStore.AddIssue(issues.Issue{
-			Level:     issues.LevelError,
-			Message:   fmt.Sprintf("invalid email address (%s): '%s'", formatErr, emailAddress),
-			Reference: ref,
-		})
-		return
+	// mailto URIs may contain multiple recipients separated by "," (https://datatracker.ietf.org/doc/html/rfc6068#autoid-2)
+	for _, recipient := range strings.Split(ref.URL.Opaque, ",") {
+		emailAddress, decodeErr := url.QueryUnescape(recipient)
+		if decodeErr != nil {
+			hT.issueStore.AddIssue(issues.Issue{
+				Level:     issues.LevelError,
+				Message:   fmt.Sprintf("cannot decode email (%s): '%s'", decodeErr, ref.URL.Opaque),
+				Reference: ref,
+			})
+			return
+		}
+		formatErr := checkmail.ValidateFormat(emailAddress)
+		if formatErr != nil {
+			hT.issueStore.AddIssue(issues.Issue{
+				Level:     issues.LevelError,
+				Message:   fmt.Sprintf("invalid email address (%s): '%s'", formatErr, emailAddress),
+				Reference: ref,
+			})
+			return
+		}
 	}
 }
 

--- a/htmltest/check-link_test.go
+++ b/htmltest/check-link_test.go
@@ -595,6 +595,12 @@ func TestMailtoEncoded(t *testing.T) {
 	tExpectIssueCount(t, hT, 0)
 }
 
+func TestMailtoMultipleRecipients(t *testing.T) {
+	// ignores valid mailto links
+	hT := tTestFile("fixtures/links/mailto_multiple_recipients.html")
+	tExpectIssueCount(t, hT, 0)
+}
+
 func TestMailtoEncodedInvalid(t *testing.T) {
 	// ignores valid mailto links
 	hT := tTestFile("fixtures/links/mailto_encoded_invalid.html")

--- a/htmltest/fixtures/links/mailto_multiple_recipients.html
+++ b/htmltest/fixtures/links/mailto_multiple_recipients.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+
+<a href="mailto:whatever@whoever.com,foo@example.com">Mail me</a>.
+
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #233. mailto URIs with multiple recipients are now handled.
- handle each recipient in a mailto URI individually (split on the `,`)
- add a test case