### PR TITLE
Fix invalid Example naming

### DIFF
--- a/issues/issue_store_test.go
+++ b/issues/issue_store_test.go
@@ -82,7 +82,7 @@ func TestIssueStoreWriteLog(t *testing.T) {
 
 }
 
-func ExampleIssueStoreDumpIssues() {
+func ExampleIssueStore_DumpIssues() {
 	// Passes for dumping all issues, ignoring LogLevel
 	iS := NewIssueStore(LevelNone, true)
 	issue1 := Issue{
@@ -108,7 +108,7 @@ func ExampleIssueStoreDumpIssues() {
 	// >>>>>>>>>>>>>>>>>>>>>>>>
 }
 
-func ExampleIssueStorePrintDocumentIssues() {
+func ExampleIssueStore_PrintDocumentIssues() {
 	iS := NewIssueStore(LevelError, false)
 	doc := htmldoc.Document{
 		SitePath: "dir/page.html",
@@ -126,7 +126,7 @@ func ExampleIssueStorePrintDocumentIssues() {
 	//   test1 --- dir/page.html --> <nil>
 }
 
-func ExampleIssueStorePrintDocumentIssuesEmpty() {
+func ExampleIssueStore_PrintDocumentIssues_empty() {
 	iS := NewIssueStore(LevelError, false)
 	doc := htmldoc.Document{
 		SitePath: "dir/page.html",

--- a/issues/issue_test.go
+++ b/issues/issue_test.go
@@ -41,7 +41,7 @@ func TestIssueSecondary(t *testing.T) {
 	assert.Equals(t, "issue1 secondary", issue1.secondary(), "http://example.com")
 }
 
-func ExampleIssuePrintLogLevel() {
+func ExampleIssue_print_logLevel() {
 	doc := htmldoc.Document{
 		SitePath: "dir/doc.html",
 	}
@@ -84,7 +84,7 @@ func ExampleIssuePrintLogLevel() {
 
 }
 
-func ExampleIssuePrintLogAll() {
+func ExampleIssue_print_logAll() {
 	doc := htmldoc.Document{
 		SitePath: "dir/doc.html",
 	}


### PR DESCRIPTION
Go 1.24 testing now [vets that examples name an actual identifier](https://go.dev/doc/go1.24#vet), so these must be renamed to match, or specify a distinct suffix.